### PR TITLE
Accidental overwrite of similar ids

### DIFF
--- a/src/inject-element.ts
+++ b/src/inject-element.ts
@@ -155,6 +155,15 @@ const injectElement = (
               b < referencingElementLen;
               b++
             ) {
+              const attrValue: string | null = referencingElements[
+                b
+              ].getAttribute(property)
+              if (
+                attrValue &&
+                !attrValue.match(new RegExp('url\\(#' + currentId + '\\)'))
+              ) {
+                continue
+              }
               referencingElements[b].setAttribute(
                 property,
                 'url(#' + newId + ')'

--- a/test/fixtures/clip-path.svg
+++ b/test/fixtures/clip-path.svg
@@ -3,6 +3,10 @@
     <clipPath id="clipPathTest">
       <rect x="16" y="16" width="32" height="32" style="fill:white;"/>
     </clipPath>
+    <clipPath id="clipPathTest2">
+      <rect x="16" y="16" width="32" height="32" style="fill:white;"/>
+    </clipPath>
   </defs>
   <circle cx="32" cy="32" r="18" stroke="1" style="fill:wheat;stroke:red;" clip-path="url(#clipPathTest)" />
+  <circle cx="32" cy="32" r="18" stroke="1" style="fill:wheat;stroke:red;" clip-path="url(#clipPathTest2)" />
 </svg>

--- a/test/renumerate-iri-elements.spec.ts
+++ b/test/renumerate-iri-elements.spec.ts
@@ -36,6 +36,9 @@ suite('renumerate iri elements', () => {
             <clipPath id="clipPathTest">
               <rect x="16" y="16" width="32" height="32" style="fill:white;"></rect>
             </clipPath>
+            <clipPath id="clipPathTest2">
+              <rect x="16" y="16" width="32" height="32" style="fill:white;"></rect>
+            </clipPath>
           </defs>
           <circle
             cx="32"
@@ -44,6 +47,14 @@ suite('renumerate iri elements', () => {
             stroke="1"
             style="fill:wheat;stroke:red;"
             clip-path="url(#clipPathTest)"
+          ></circle>
+          <circle
+            cx="32"
+            cy="32"
+            r="18"
+            stroke="1"
+            style="fill:wheat;stroke:red;"
+            clip-path="url(#clipPathTest2)"
           ></circle>
         </svg>
       `)
@@ -74,6 +85,9 @@ suite('renumerate iri elements', () => {
             <clipPath id="clipPathTest-1">
               <rect x="16" y="16" width="32" height="32" style="fill:white;"></rect>
             </clipPath>
+            <clipPath id="clipPathTest2-1">
+              <rect x="16" y="16" width="32" height="32" style="fill:white;"></rect>
+            </clipPath>
           </defs>
           <circle
             cx="32"
@@ -82,6 +96,14 @@ suite('renumerate iri elements', () => {
             stroke="1"
             style="fill:wheat;stroke:red;"
             clip-path="url(#clipPathTest-1)"
+          ></circle>
+          <circle
+            cx="32"
+            cy="32"
+            r="18"
+            stroke="1"
+            style="fill:wheat;stroke:red;"
+            clip-path="url(#clipPathTest2-1)"
           ></circle>
         </svg>
       `)


### PR DESCRIPTION
# Fixes

There's a bug where IDs will get overwritten by accident.

If one ID happens to be the prefix of another id, the attribute selector: `'[' + property + '*="' + currentId + '"]'` will include some elements incorrectly.

Example:

```
<defs>
  <clipPath id="foobarPath">...</clipPath>
  <clipPath id="foobarPath2">...</clipPath>
</defs>
<g clip-path="url(#foobarPath)">...</g>
<g clip-path="url(#foobarPath2)">...</g>
```

This incorrectly results in something like:

```
<defs>
  <clipPath id="foobarPath-1">...</clipPath>
  <clipPath id="foobarPath2-2">...</clipPath>
</defs>
<g clip-path="url(#foobarPath-1)">...</g>
<g clip-path="url(#foobarPath-1)">...</g>
```


I've added a simple condition that just does an extra check to verify that the item we're updating is exactly corresponding to the `currentId`. If there's a better solution, let me know.

Tests are passing.