### PR TITLE
Transfer width and height attributes from source element

### DIFF
--- a/src/inject-element.ts
+++ b/src/inject-element.ts
@@ -70,6 +70,18 @@ const injectElement = (
       svg.setAttribute('title', imgTitle)
     }
 
+    const imgWidth = el.getAttribute('width')
+    /* istanbul ignore else */
+    if (imgWidth) {
+      svg.setAttribute('width', imgWidth)
+    }
+
+    const imgHeight = el.getAttribute('height')
+    /* istanbul ignore else */
+    if (imgHeight) {
+      svg.setAttribute('height', imgHeight)
+    }
+
     const mergedClasses = Array.from(
       new Set([
         ...(svg.getAttribute('class') || '').split(' '),

--- a/test/svg-injector.spec.ts
+++ b/test/svg-injector.spec.ts
@@ -237,10 +237,12 @@ suite('svg injector', () => {
           data-bar="bar"
           data-foo="foo"
           data-src="/fixtures/thumb-up.svg"
+          height="100"
           id="thumb-up"
           src="/some/other/url.svg"
           style="height:20px;"
           title="thumb-up"
+          width="100"
         ></div>
       </div>
       `
@@ -253,12 +255,12 @@ suite('svg injector', () => {
           data-bar="bar"
           data-foo="foo"
           data-src="/fixtures/thumb-up.svg"
-          height="8"
+          height="100"
           id="thumb-up"
           style="height:20px;"
           title="thumb-up"
           viewBox="0 0 8 8"
-          width="8"
+          width="100"
           xmlns="http://www.w3.org/2000/svg"
           xmlns:xlink="http://www.w3.org/1999/xlink"
         >


### PR DESCRIPTION
Proposed feature from #32.

Doing this blows away any `width` and `height` attributes defined on the SVG being loaded. Think this will be ok, but if it causes issues we could look at hiding it behind an option or something.

For that reason it seems like a potential breaking change, so will be released as a major version.