### PR TITLE
Handle data:image/svg+xml URLs without making requests

### DIFF
--- a/src/make-ajax-request.ts
+++ b/src/make-ajax-request.ts
@@ -4,12 +4,17 @@ import isLocal from './is-local'
 const makeAjaxRequest = (
   url: string,
   httpRequestWithCredentials: boolean,
-  callback: (error: Error | null, httpRequest: Pick<XMLHttpRequest, 'responseXML'>) => void,
+  callback: (
+    error: Error | null,
+    httpRequest: Pick<XMLHttpRequest, 'responseXML'>,
+  ) => void,
 ) => {
   if (url.startsWith('data:image/svg+xml,')) {
     const src = decodeURIComponent(url.slice('data:image/svg+xml,'.length))
     const parser = new DOMParser()
-    callback(null, { responseXML: { documentElement: parser.parseFromString(src, 'image/svg+xml') } })
+    callback(null, {
+      responseXML: parser.parseFromString(src, 'image/svg+xml'),
+    })
     return
   }
   const httpRequest = new XMLHttpRequest()

--- a/src/make-ajax-request.ts
+++ b/src/make-ajax-request.ts
@@ -4,8 +4,14 @@ import isLocal from './is-local'
 const makeAjaxRequest = (
   url: string,
   httpRequestWithCredentials: boolean,
-  callback: (error: Error | null, httpRequest: XMLHttpRequest) => void,
+  callback: (error: Error | null, httpRequest: Pick<XMLHttpRequest, 'responseXML'>) => void,
 ) => {
+  if (url.startsWith('data:image/svg+xml,')) {
+    const src = decodeURIComponent(url.slice('data:image/svg+xml,'.length))
+    const parser = new DOMParser()
+    callback(null, { responseXML: { documentElement: parser.parseFromString(src, 'image/svg+xml') } })
+    return
+  }
   const httpRequest = new XMLHttpRequest()
 
   httpRequest.onreadystatechange = () => {


### PR DESCRIPTION
Vite 5 started automatically inlining small SVG files, attempting to request these with AJAX causes CSP issues, after some digging it seemed the most expedient solution was to adjust the request logic so it will avoid making a request if it is given a data URL with the correct MIME type and return the expected structure so it can be used immediately.

I haven't added new tests but I have tested this change and it resolved the issue. This isn't entirely comprehensive, there are additional cases I didn't account for like base64 encoding. If that is needed I can add it as well or this can be used as a starting point.

Relevant commit from Vite: https://github.com/vitejs/vite/commit/5acda5e