### PR TITLE
Use image/svg+xml for overrideMimeType instead of text/xml

### DIFF
--- a/src/make-ajax-request.ts
+++ b/src/make-ajax-request.ts
@@ -65,7 +65,7 @@ const makeAjaxRequest = (
   /* istanbul ignore else */
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (httpRequest.overrideMimeType) {
-    httpRequest.overrideMimeType('text/xml')
+    httpRequest.overrideMimeType('image/svg+xml')
   }
 
   httpRequest.send()


### PR DESCRIPTION
Switch `overrideMimeType` from `text/xml` to `image/svg+xml`. Both are XML MIME types so `responseXML` is populated either way, but `image/svg+xml` is more appropriate for SVG content and avoids a content-type validation failure in older Chromium versions where `getResponseHeader` returns the overridden type instead of the actual server header.

Fixes #1493