### PR TITLE
Add data URL support for data:image/svg+xml URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ SVGInjector(document.getElementById('inject-me'))
 
 You can inject individual symbols from an SVG sprite sheet by appending a fragment identifier (e.g. `sprite.svg#icon-star`) to the `data-src` URL. See the [sprite usage example](https://github.com/tanem/svg-injector/tree/master/examples/sprite-usage) for full documentation and known limitations.
 
+## Data URL Support
+
+When a bundler like Vite inlines small SVGs as `data:image/svg+xml` URLs, the library parses the SVG content directly from the data URL without making a network request. This avoids Content Security Policy violations and unnecessary XHR overhead. See the [data URL usage example](https://github.com/tanem/svg-injector/tree/master/examples/data-url-usage) for supported formats and known limitations.
+
 ## Avoiding XSS
 
 Be careful when injecting arbitrary third-party SVGs into the DOM, as this opens the door to XSS attacks. If you must inject third-party SVGs, it is highly recommended to sanitise the SVG before injecting. The following example uses [DOMPurify](https://github.com/cure53/DOMPurify) to strip out attributes and tags that can execute arbitrary JavaScript. Note that this can alter the behaviour of the SVG.
@@ -53,6 +57,7 @@ SVGInjector(document.getElementById('inject-me'), {
 - Basic Usage: [Source](https://github.com/tanem/svg-injector/tree/master/examples/basic-usage) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/basic-usage)
 - API Usage: [Source](https://github.com/tanem/svg-injector/tree/master/examples/api-usage) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/api-usage)
 - IRI Renumeration: [Source](https://github.com/tanem/svg-injector/tree/master/examples/iri-renumeration) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/iri-renumeration)
+- Data URL Usage: [Source](https://github.com/tanem/svg-injector/tree/master/examples/data-url-usage) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/data-url-usage)
 - Sprite Usage: [Source](https://github.com/tanem/svg-injector/tree/master/examples/sprite-usage) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/sprite-usage)
 - UMD Build (Development): [Source](https://github.com/tanem/svg-injector/tree/master/examples/umd-dev) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/umd-dev)
 - UMD Build (Production): [Source](https://github.com/tanem/svg-injector/tree/master/examples/umd-prod) | [Sandbox](https://codesandbox.io/s/github/tanem/svg-injector/tree/master/examples/umd-prod)

--- a/examples/data-url-usage/README.md
+++ b/examples/data-url-usage/README.md
@@ -1,0 +1,46 @@
+# Data URL Usage
+
+Inject SVGs from `data:image/svg+xml` URLs without making network requests. This is useful when bundlers like Vite inline small SVG files as data URIs during the build process.
+
+## Usage
+
+```html
+<!-- URL-encoded (Vite's default for SVGs without <text>) -->
+<div
+  data-src="data:image/svg+xml,%3Csvg%20xmlns%3D'...'%3E...%3C%2Fsvg%3E"
+></div>
+
+<!-- Base64-encoded (Vite's default for SVGs containing <text>) -->
+<div data-src="data:image/svg+xml;base64,PHN2Zy..."></div>
+```
+
+```js
+import { SVGInjector } from '@tanem/svg-injector'
+
+SVGInjector(document.querySelectorAll('[data-src]'))
+```
+
+The library detects the `data:image/svg+xml` prefix and parses the SVG content directly using `DOMParser`. No XHR is made, which avoids Content Security Policy violations that would otherwise occur when attempting to fetch a `data:` URI.
+
+## Supported formats
+
+- `data:image/svg+xml,` followed by URL-encoded SVG (percent-encoded).
+- `data:image/svg+xml;base64,` followed by base64-encoded SVG.
+- `data:image/svg+xml;charset=utf-8,` followed by URL-encoded SVG.
+
+## Fragment identifiers
+
+Fragment identifiers work with data URLs the same way as with regular URLs. If a data URL contains an inlined SVG sprite, you can extract a specific symbol:
+
+```html
+<div data-src="data:image/svg+xml,...encoded-sprite...#icon-name"></div>
+```
+
+## Caching
+
+Data URLs bypass the request cache entirely since the SVG content is already embedded in the URL. The `cacheRequests` option has no effect on data URL elements.
+
+## Limitations
+
+- Only `data:image/svg+xml` MIME types are supported. Other image formats (e.g. `data:image/png`) are not handled.
+- Parse errors from malformed SVG content are reported through the `afterEach` error callback.

--- a/examples/data-url-usage/index.html
+++ b/examples/data-url-usage/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SVGInjector Data URL Usage Example</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 2rem;
+      }
+      .icon {
+        width: 48px;
+        height: 48px;
+        margin: 0.5rem;
+        color: #333;
+        transition: color 0.2s;
+      }
+      .icon:hover {
+        color: #e74c3c;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>SVG Data URL Injection</h1>
+    <p>
+      These icons use <code>data:image/svg+xml</code> URLs in their
+      <code>data-src</code> attributes, as a bundler like Vite would produce.
+      The SVG content is parsed directly from the data URL without making a
+      network request.
+    </p>
+    <h2>URL-encoded</h2>
+    <div
+      class="inject-me icon"
+      data-src="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'8'%20height%3D'8'%20viewBox%3D'0%200%208%208'%3E%3Cpath%20d%3D'M4.47%200c-.19.02-.37.15-.47.34-.13.26-1.09%202.19-1.28%202.38-.19.19-.44.28-.72.28v4h3.5c.21%200%20.39-.13.47-.31%200%200%201.03-2.91%201.03-3.19%200-.28-.22-.5-.5-.5h-1.5c-.28%200-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47%203v4h1v-4h-1z'%2F%3E%3C%2Fsvg%3E"
+    ></div>
+    <h2>Base64-encoded</h2>
+    <div
+      class="inject-me icon"
+      data-src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc4JyBoZWlnaHQ9JzgnIHZpZXdCb3g9JzAgMCA4IDgnPjxwYXRoIGQ9J001IDFMMyAzSDFWN0gzTDUgOVYxWicvPjwvc3ZnPg=="
+    ></div>
+    <script type="module" src="index.ts"></script>
+  </body>
+</html>

--- a/examples/data-url-usage/index.ts
+++ b/examples/data-url-usage/index.ts
@@ -1,0 +1,3 @@
+import { SVGInjector } from '@tanem/svg-injector'
+
+SVGInjector(document.getElementsByClassName('inject-me'))

--- a/examples/data-url-usage/package.json
+++ b/examples/data-url-usage/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "data-url-usage",
+  "version": "1.0.0",
+  "description": "SVGInjector Data URL Usage Example",
+  "scripts": {
+    "build": "parcel build index.html",
+    "start": "parcel index.html --open"
+  },
+  "dependencies": {
+    "@tanem/svg-injector": "latest"
+  },
+  "overrides": {
+    "braces": "3.0.3"
+  },
+  "keywords": [
+    "@tanem/svg-injector"
+  ],
+  "devDependencies": {
+    "parcel": "2.16.4"
+  }
+}

--- a/examples/data-url-usage/tsconfig.json
+++ b/examples/data-url-usage/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "esnext",
+    "target": "es2020",
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "rootDir": ".",
+    "moduleResolution": "bundler"
+  },
+  "files": ["index.ts"]
+}

--- a/src/parse-data-url.ts
+++ b/src/parse-data-url.ts
@@ -1,0 +1,56 @@
+const dataUrlPrefix = 'data:image/svg+xml'
+
+// Parses an SVG data URL (URL-encoded or base64) into an SVGSVGElement without
+// making a network request. Returns null for non-data-URL strings so callers
+// can fall through to XHR loading.
+const parseDataUrl = (url: string): SVGSVGElement | Error | null => {
+  if (!url.startsWith(dataUrlPrefix)) {
+    return null
+  }
+
+  const rest = url.slice(dataUrlPrefix.length)
+
+  let svgString: string
+
+  if (rest.startsWith(';base64,')) {
+    try {
+      svgString = atob(rest.slice(';base64,'.length))
+    } catch {
+      return new Error('Invalid base64 in data URL')
+    }
+  } else if (rest.startsWith(',')) {
+    try {
+      svgString = decodeURIComponent(rest.slice(','.length))
+    } catch {
+      return new Error('Invalid encoding in data URL')
+    }
+  } else if (rest.startsWith(';charset=utf-8,')) {
+    // Some tools emit an explicit charset parameter before the comma.
+    try {
+      svgString = decodeURIComponent(rest.slice(';charset=utf-8,'.length))
+    } catch {
+      return new Error('Invalid encoding in data URL')
+    }
+  } else {
+    return new Error('Unsupported data URL format')
+  }
+
+  const doc = new DOMParser().parseFromString(svgString, 'image/svg+xml')
+
+  // DOMParser returns a document with a <parsererror> element on invalid input
+  // rather than throwing.
+  const parserError = doc.querySelector('parsererror')
+  if (parserError) {
+    return new Error(
+      'Data URL SVG parse error: ' + parserError.textContent.trim(),
+    )
+  }
+
+  if (!(doc.documentElement instanceof SVGSVGElement)) {
+    return new Error('Data URL did not contain a valid SVG element')
+  }
+
+  return doc.documentElement
+}
+
+export default parseDataUrl

--- a/test/data-url.test.ts
+++ b/test/data-url.test.ts
@@ -1,0 +1,348 @@
+import { expect, test } from './playwright/coverage'
+import { formatHtml, injectSvg, setupPage } from './playwright/test-utils'
+
+const thumbUpPath =
+  'M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z'
+const thumbUpPathElement = `<path d="${thumbUpPath}"></path>`
+
+const thumbUpSvgRaw =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8"><path d="M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z"/></svg>'
+
+const spriteRaw =
+  '<svg xmlns="http://www.w3.org/2000/svg"><symbol id="icon-thumb-up" viewBox="0 0 8 8"><path d="M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z"/></symbol></svg>'
+
+// URL-encoded data URL. Vite produces this format for SVGs without <text>.
+const encodedDataUrl = 'data:image/svg+xml,' + encodeURIComponent(thumbUpSvgRaw)
+
+// Base64-encoded data URL. Vite produces this format for SVGs containing
+// <text>.
+const base64DataUrl =
+  'data:image/svg+xml;base64,' +
+  Buffer.from(thumbUpSvgRaw, 'utf8').toString('base64')
+
+// URL-encoded with explicit charset parameter (some tools emit this).
+const charsetDataUrl =
+  'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(thumbUpSvgRaw)
+
+// Sprite as a URL-encoded data URL with a fragment identifier.
+const spriteDataUrl =
+  'data:image/svg+xml,' + encodeURIComponent(spriteRaw) + '#icon-thumb-up'
+
+test.describe('data URL support', () => {
+  test('URL-encoded data URL', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${encodedDataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    const actual = formatHtml(result.html)
+    const expected = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${encodedDataUrl}" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
+    expect(actual).toBe(expected)
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('base64-encoded data URL', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${base64DataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    const actual = formatHtml(result.html)
+    const expected = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${base64DataUrl}" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
+    expect(actual).toBe(expected)
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('data URL with explicit charset', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${charsetDataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    const actual = formatHtml(result.html)
+    const expected = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${charsetDataUrl}" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
+    expect(actual).toBe(expected)
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('multiple data URL elements', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${encodedDataUrl}"
+        ></div>
+        <div
+          class="inject-me"
+          data-src="${base64DataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+      selectorAll: true,
+    })
+
+    expect(result.afterEachCalls).toHaveLength(2)
+    expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(result.afterEachCalls[1]!.error).toBe(null)
+    expect(result.elementsLoaded).toBe(2)
+  })
+
+  test('data URL with fragment identifier (sprite)', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${spriteDataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    const actual = formatHtml(result.html)
+    const expected = `<svg viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${spriteDataUrl}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
+    expect(actual).toBe(expected)
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('data URL with nonexistent symbol', async ({ page }) => {
+    await setupPage(page)
+
+    const spriteDataUrlBadSymbol =
+      'data:image/svg+xml,' + encodeURIComponent(spriteRaw) + '#nonexistent'
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${spriteDataUrlBadSymbol}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toContain(
+      'Symbol "nonexistent" not found',
+    )
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('invalid SVG content in data URL', async ({ page }) => {
+    await setupPage(page)
+
+    const badDataUrl = 'data:image/svg+xml,' + encodeURIComponent('<not-svg/>')
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${badDataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toContain(
+      'Data URL did not contain a valid SVG element',
+    )
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('malformed base64 data URL', async ({ page }) => {
+    await setupPage(page)
+
+    const badBase64Url = 'data:image/svg+xml;base64,!!!not-base64!!!'
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${badBase64Url}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBeTruthy()
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('unsupported data URL format', async ({ page }) => {
+    await setupPage(page)
+
+    const badFormatUrl = 'data:image/svg+xml;charset=iso-8859-1,<svg/>'
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${badFormatUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toContain(
+      'Unsupported data URL format',
+    )
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('attributes transferred from data URL element', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="my-icon"
+          data-src="${encodedDataUrl}"
+          id="my-svg"
+          title="Thumb Up"
+          width="24"
+          height="24"
+          style="color:red;"
+          data-foo="bar"
+        ></div>
+      `,
+      selector: '#my-svg',
+    })
+
+    const actual = formatHtml(result.html)
+    const expected = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 8 8" id="my-svg" title="Thumb Up" class="injected-svg my-icon" style="color:red;" data-src="${encodedDataUrl}" data-foo="bar" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
+    expect(actual).toBe(expected)
+  })
+
+  test('data URL with cacheRequests disabled', async ({ page }) => {
+    await setupPage(page)
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${encodedDataUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+      options: { cacheRequests: false },
+    })
+
+    const actual = formatHtml(result.html)
+    const expected = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${encodedDataUrl}" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
+    expect(actual).toBe(expected)
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('invalid percent-encoding in URL-encoded data URL', async ({ page }) => {
+    await setupPage(page)
+
+    // %ZZ is not a valid percent-encoded sequence, so decodeURIComponent will
+    // throw.
+    const badEncodingUrl = 'data:image/svg+xml,%ZZ'
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${badEncodingUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toContain(
+      'Invalid encoding in data URL',
+    )
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('invalid percent-encoding in charset data URL', async ({ page }) => {
+    await setupPage(page)
+
+    const badCharsetUrl = 'data:image/svg+xml;charset=utf-8,%ZZ'
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${badCharsetUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toContain(
+      'Invalid encoding in data URL',
+    )
+    expect(result.elementsLoaded).toBe(1)
+  })
+
+  test('malformed XML in data URL triggers parse error', async ({ page }) => {
+    await setupPage(page)
+
+    // Unclosed tag produces a DOMParser parsererror, unlike <not-svg/> which
+    // parses successfully but fails the SVGSVGElement check.
+    const malformedXmlUrl = 'data:image/svg+xml,' + encodeURIComponent('<svg><')
+
+    const result = await injectSvg(page, {
+      html: `
+        <div
+          class="inject-me"
+          data-src="${malformedXmlUrl}"
+        ></div>
+      `,
+      selector: '.inject-me',
+    })
+
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toContain(
+      'Data URL SVG parse error',
+    )
+    expect(result.elementsLoaded).toBe(1)
+  })
+})

--- a/test/data-url.test.ts
+++ b/test/data-url.test.ts
@@ -113,9 +113,16 @@ test.describe('data URL support', () => {
       selectorAll: true,
     })
 
+    const actualFirst = formatHtml(result.afterEachCalls[0]!.svg ?? '')
+    const actualSecond = formatHtml(result.afterEachCalls[1]!.svg ?? '')
+    const expectedEncoded = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${encodedDataUrl}" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+    const expectedBase64 = `<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8" class="injected-svg inject-me" data-src="${base64DataUrl}" xmlns:xlink="http://www.w3.org/1999/xlink">${thumbUpPathElement}</svg>`
+
     expect(result.afterEachCalls).toHaveLength(2)
     expect(result.afterEachCalls[0]!.error).toBe(null)
+    expect(actualFirst).toBe(expectedEncoded)
     expect(result.afterEachCalls[1]!.error).toBe(null)
+    expect(actualSecond).toBe(expectedBase64)
     expect(result.elementsLoaded).toBe(2)
   })
 
@@ -161,6 +168,7 @@ test.describe('data URL support', () => {
     expect(result.afterEachCalls[0]!.error).toContain(
       'Symbol "nonexistent" not found',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -183,6 +191,7 @@ test.describe('data URL support', () => {
     expect(result.afterEachCalls[0]!.error).toContain(
       'Data URL did not contain a valid SVG element',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -202,7 +211,8 @@ test.describe('data URL support', () => {
     })
 
     expect(result.afterEachCalls).toHaveLength(1)
-    expect(result.afterEachCalls[0]!.error).toBeTruthy()
+    expect(result.afterEachCalls[0]!.error).toBe('Invalid base64 in data URL')
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -225,6 +235,7 @@ test.describe('data URL support', () => {
     expect(result.afterEachCalls[0]!.error).toContain(
       'Unsupported data URL format',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -297,6 +308,7 @@ test.describe('data URL support', () => {
     expect(result.afterEachCalls[0]!.error).toContain(
       'Invalid encoding in data URL',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -319,6 +331,7 @@ test.describe('data URL support', () => {
     expect(result.afterEachCalls[0]!.error).toContain(
       'Invalid encoding in data URL',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -343,6 +356,7 @@ test.describe('data URL support', () => {
     expect(result.afterEachCalls[0]!.error).toContain(
       'Data URL SVG parse error',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 })

--- a/test/local.test.ts
+++ b/test/local.test.ts
@@ -35,9 +35,11 @@ test.describe('local', () => {
     })
 
     expect(result.elementsLoaded).toBe(1)
-    expect(result.afterEachCalls[0]?.error).toBe(
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(
       'Note: SVG injection ajax calls do not work locally without adjusting security settings in your browser. Or consider using a local webserver.',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
   })
 
   // Playwright browsers enforce cross-origin restrictions on file:// pages, so

--- a/test/no-extension.test.ts
+++ b/test/no-extension.test.ts
@@ -20,7 +20,12 @@ test.describe('no extension', () => {
     // no error is returned. Chromium and Firefox surface the missing header.
     const expectedError =
       browserName === 'webkit' ? null : 'Content type not found'
-    expect(result.afterEachCalls[0]?.error ?? null).toBe(expectedError)
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error ?? null).toBe(expectedError)
+    if (browserName !== 'webkit') {
+      expect(result.afterEachCalls[0]!.svg).toBe(null)
+    }
+    expect(result.elementsLoaded).toBe(1)
   })
 
   test('invalid media type', async ({ page }) => {
@@ -36,7 +41,10 @@ test.describe('no extension', () => {
       selector: '.inject-me',
     })
 
-    expect(result.afterEachCalls[0]?.error).toBe('invalid media type')
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe('invalid media type')
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
   })
 
   test('invalid content type', async ({ page }) => {
@@ -52,9 +60,12 @@ test.describe('no extension', () => {
       selector: '.inject-me',
     })
 
-    expect(result.afterEachCalls[0]?.error).toBe(
+    expect(result.afterEachCalls).toHaveLength(1)
+    expect(result.afterEachCalls[0]!.error).toBe(
       'Invalid content type: text/html',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
+    expect(result.elementsLoaded).toBe(1)
   })
 
   test('image/svg+xml', async ({ page }) => {

--- a/test/sprite.test.ts
+++ b/test/sprite.test.ts
@@ -106,6 +106,7 @@ test.describe('sprite support', () => {
     expect(result.afterEachCalls[0]!.error).toBe(
       'Symbol "nonexistent" not found in /fixtures/sprite.svg',
     )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 
@@ -171,7 +172,10 @@ test.describe('sprite support', () => {
     })
 
     expect(result.afterEachCalls).toHaveLength(1)
-    expect(result.afterEachCalls[0]!.error).toBeTruthy()
+    expect(result.afterEachCalls[0]!.error).toBe(
+      'Unable to load SVG file: /fixtures/nonexistent-sprite.svg',
+    )
+    expect(result.afterEachCalls[0]!.svg).toBe(null)
     expect(result.elementsLoaded).toBe(1)
   })
 })


### PR DESCRIPTION
Parse SVG content directly from data URLs without making XHR requests. This avoids Content Security Policy violations when bundlers like Vite inline small SVGs as data URIs.

Supported formats: URL-encoded (,), base64 (;base64,), and charset (;charset=utf-8,). Fragment identifiers work for sprite extraction. DOMParser is used for parsing with parsererror detection.

Inspired by @nathan-knight’s idea in #1467, reworked for the current codebase 🙏 