### PR TITLE
Commit the manual transport checks as test/manual

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 coverage
 dist
-# Git-excluded scratch area, and it holds a copied build artefact. Absent for
-# anyone else, so this entry is inert for them and keeps `npm test` passing here.
+# Git-excluded scratch area. Absent for anyone else, so this entry is inert for
+# them and keeps `npm test` passing here.
 roadmap
 playwright-report
 playwright-report-examples

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,11 @@ come from `setupPage(page, { fixtureOverrides })`, keyed by fixture path.
 That mocking is the suite's blind spot: real-server and `file://` behaviour is
 simulated, so a change to `make-ajax-request.ts` needs checking by hand against
 an actual server or an actual `file://` load before it is believed.
+`test/manual/` is that check. It is not run by `npm test` and not wired into
+CI, deliberately: nothing in it is mocked, which is the whole point. Run it and
+record the result in the PR when you touch `make-ajax-request.ts` or
+`load-svg-cached.ts`, and update its expected values in the same commit as any
+deliberate change to either.
 
 All three browser projects must pass. Coverage numbers come from chromium
 alone, because Playwright's `page.coverage` is Chromium-only, but the whole

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,7 +63,9 @@ export default tseslint.config(
     },
   },
   {
-    files: ['test/**/*.ts', 'playwright.config.ts'],
+    // `test/manual/**/*.mjs` is the hand-run transport harness: a node server
+    // and two Playwright probes that report their results on stdout.
+    files: ['test/**/*.ts', 'test/manual/**/*.mjs', 'playwright.config.ts'],
     rules: {
       // Allow console in tests for debugging
       'no-console': 'off',

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -113,6 +113,10 @@ Recorded so a later run has something to compare against.
 - 12.0.0, 2026-08-03, stock browsers: 23/23 HTTP in Chrome 151, Firefox 146 and
   Safari 26.5; 3/3 `file://` in Chrome 151 and Safari 26.5.
 - 12.0.0, 2026-08-04, after the move to `test/manual/`: 23/23 HTTP in Chrome
-  151 and in all three Playwright engines. `file://` re-run in the Playwright
-  engines only: 3/3 in chromium with `--allow-file-access-from-files` and in
-  firefox.
+  151 and in all three Playwright engines; 3/3 `file://` in Safari 26.5, and in
+  Playwright chromium with `--allow-file-access-from-files` and firefox.
+
+  Safari reported status 0 with no `Content-Type` on all three, and `./icon.svg`
+  injected anyway. That is the `.svg` bypass and the status-0 allowance both
+  doing real work: in Chrome and Firefox the same row passes on a synthesised
+  200, so Safari is the only run that demonstrates either is needed.

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -1,0 +1,118 @@
+# Manual transport checks
+
+`test/playwright/test-utils.ts` routes every request, so the Playwright suite
+never talks to a server. Real-server and `file://` behaviour is simulated there,
+which makes it the suite's blind spot: a change to `make-ajax-request.ts` or
+`load-svg-cached.ts` is not under test until it has been run against a genuine
+response.
+
+These checks are that run. They are deliberately not wired into CI: their value
+is that nothing is mocked, and automating them on a hosted runner would mean
+mocking the parts that make them worth having.
+
+Run them when you change either of those two files, and record the result in the
+PR.
+
+## HTTP
+
+`server.mjs` is a plain node server on port 4180. It serves headers a static
+server cannot be made to send: a missing `Content-Type`, a header with no media
+type, a malformed one, a 302, a delayed response, and a `/hits` endpoint that
+counts requests per path.
+
+```
+npm run build
+node test/manual/server.mjs
+open http://localhost:4180/
+```
+
+22 cases plus a refetch check, 23 rows. The page tabulates expected against
+actual and prints a pass/fail summary. Expected values are derived from `src/make-ajax-request.ts` and
+`src/load-svg-cached.ts`, so changing either deliberately means updating the
+expectations here in the same commit.
+
+Every case asserts the number of `afterEach` calls as well as the outcome.
+Reporting twice is a failure mode the mocked suite is poorly placed to catch,
+since it turns on real abort and readystate semantics. The cases worth
+understanding:
+
+| Case | Why it is here |
+| --- | --- |
+| `cacheRequests: false` with a rejected content type | Rejecting the header aborts the request, and the abort re-enters the readystate handler. Route interception does not reproduce that second event, so this is the only place the exactly-once accounting is really tested. |
+| 200 with well-formed non-SVG XML | Reaches the non-SVG-root branch, which needs a body that parses cleanly. A lowercase `<!doctype` fails XML parsing outright and lands in the unparseable branch instead, so both bodies are served. |
+| Same URL injected twice after a parse failure | That a failed load is not cached. Asserted by counting server hits, because nothing on the page distinguishes a refetch from a cache entry parked on the loading sentinel. |
+| `.svg` only in the query string | The extension bypass matches the pathname, not the whole URL, against a genuine server header. |
+| 500 with an unparseable body vs 500 with a valid SVG body | Two different branches. `responseXML === null` is tested before the status, so only a parseable body reaches `There was a problem injecting the SVG`. |
+
+Run it in Chrome, Firefox and Safari. All three should report 23/23.
+
+## file://
+
+`file-protocol/index.html` covers what a local file load reports, which is the
+only reason the status-0 allowance and the `.svg` extension bypass in
+`make-ajax-request.ts` exist. Both look like dead code until Safari is tried.
+
+The page loads `../../dist/svg-injector.iife.js` as a classic script, so it
+always runs against the current build:
+
+```
+npm run build
+```
+
+Confirm the page reports `location.protocol` as `file:` before trusting any
+result. Served over HTTP it passes for the wrong reason.
+
+Every engine blocks `file://` → `file://` XHR at default settings, so the
+browser has to be told to allow it or case 1 cannot pass. Stock Firefox has no
+comparable switch, so use Chrome and Safari:
+
+```
+# Chrome. The separate profile matters: a running Chrome ignores the flag.
+open -na "Google Chrome" --args --allow-file-access-from-files \
+  --user-data-dir="$HOME/.chrome-file-check" \
+  "file://$PWD/test/manual/file-protocol/index.html"
+
+# Safari, after Develop -> Developer Settings -> Disable Local File Restrictions
+open -a Safari test/manual/file-protocol/index.html
+```
+
+Three cases. Each asserts exactly one `afterEach`, and the table records the
+status and `Content-Type` the transport reported, so the reason behind each
+verdict is visible rather than inferred from one browser:
+
+- `./icon.svg` injects, via the `.svg` extension bypass.
+- `./icon-no-extension` resolves rather than hanging. Whether it injects or
+  errors is engine-specific, because what a browser reports for a local file is:
+  Chrome sniffs `text/plain` and injects, Firefox reports `text/xml` and
+  rejects, Safari sends no header and rejects with `Content type not found`.
+- `./does-not-exist.svg` reports an error rather than hanging.
+
+Safari is the one that cannot be skipped. It is the only engine still reporting
+status 0 with no `Content-Type`, so it is the only one where those two
+allowances are load-bearing.
+
+### Playwright pre-check
+
+```
+node test/manual/file-protocol/probe.mjs
+node test/manual/file-protocol/readystate-probe.mjs
+```
+
+`probe.mjs` drives the page over a real `file://` load in all three Playwright
+engines; `readystate-probe.mjs` traces the raw XHR behind it. Useful for a quick
+signal, but not a substitute: Playwright's builds lag the stock browsers and set
+their own preferences, its Firefox permits a local XHR that stock Firefox
+blocks, and its webkit cannot lift the local file restriction at all, which is
+the engine that matters here. The two runs that cannot lift it are labelled in
+the output so their failures do not read as regressions.
+
+## Last run
+
+Recorded so a later run has something to compare against.
+
+- 12.0.0, 2026-08-03, stock browsers: 23/23 HTTP in Chrome 151, Firefox 146 and
+  Safari 26.5; 3/3 `file://` in Chrome 151 and Safari 26.5.
+- 12.0.0, 2026-08-04, after the move to `test/manual/`: 23/23 HTTP in Chrome
+  151 and in all three Playwright engines. `file://` re-run in the Playwright
+  engines only: 3/3 in chromium with `--allow-file-access-from-files` and in
+  firefox.

--- a/test/manual/file-protocol/icon-no-extension
+++ b/test/manual/file-protocol/icon-no-extension
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <path id="a" d="M0 10h8V0H0v10zm0 8h8v-6H0v6zm10 0h8V8h-8v10zm0-18v6h8V0h-8z"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h24v24H0z"/>
+        <g transform="translate(3 3)">
+            <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+            </mask>
+            <use fill="#000" fill-opacity=".7" xlink:href="#a"/>
+            <g mask="url(#b)">
+                <path fill="#004876" fill-rule="nonzero" d="M-103-11535H-3v100h-100z"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/test/manual/file-protocol/icon.svg
+++ b/test/manual/file-protocol/icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <path id="a" d="M0 10h8V0H0v10zm0 8h8v-6H0v6zm10 0h8V8h-8v10zm0-18v6h8V0h-8z"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h24v24H0z"/>
+        <g transform="translate(3 3)">
+            <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+            </mask>
+            <use fill="#000" fill-opacity=".7" xlink:href="#a"/>
+            <g mask="url(#b)">
+                <path fill="#004876" fill-rule="nonzero" d="M-103-11535H-3v100h-100z"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/test/manual/file-protocol/index.html
+++ b/test/manual/file-protocol/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en-NZ">
+  <head>
+    <meta charset="utf-8" />
+    <title>svg-injector — file:// transport checks</title>
+    <!--
+      A classic script, so the browser loads it from a sibling directory over
+      file:// without a server. An ES module would not: file:// module loads
+      are blocked as cross-origin. `npm run build` writes it, so the check
+      always runs against the current build rather than a vendored copy.
+    -->
+    <script src="../../dist/svg-injector.iife.js"></script>
+    <style>
+      body { font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; padding: 2rem; }
+      table { border-collapse: collapse; margin-top: 1rem; }
+      th, td { border: 1px solid #bbb; padding: 0.4rem 0.7rem; text-align: left; }
+      .pass { background: #e6f5e9; }
+      .fail { background: #fdeceb; }
+      #summary { font-weight: bold; font-size: 1.05rem; }
+      #host { position: absolute; left: -9999px; }
+    </style>
+  </head>
+  <body>
+    <h1>file:// transport check</h1>
+    <p>
+      Open this file directly from disk, not through a server. What the
+      transport reports for <code>file://</code> is engine-specific, so the
+      table records the observed status and <code>Content-Type</code> beside
+      each verdict: those two values are what the <code>.svg</code> extension
+      bypass and <code>isLocal()</code> exist to handle, and they cannot be
+      inferred from one browser.
+    </p>
+    <p>
+      Chromium and WebKit block <code>file://</code> &rarr;
+      <code>file://</code> XHR at default settings. In Chrome, run with
+      <code>--allow-file-access-from-files</code>; in Safari, enable
+      Develop &rarr; Developer Settings &rarr; Disable Local File
+      Restrictions. Without that, every case reports the local-security error
+      and only the no-hang assertions mean anything.
+    </p>
+    <p id="protocol"></p>
+    <div id="summary">running…</div>
+    <div id="out"></div>
+    <div id="host"></div>
+
+    <script>
+      const inject = window.SVGInjector.SVGInjector
+      const host = document.getElementById('host')
+      document.getElementById('protocol').textContent =
+        `location.protocol is "${window.location.protocol}" — must be "file:" for this check to mean anything.`
+
+      // `settled` decides the verdict: 'injects', 'errors', or 'either' where
+      // the outcome is legitimately engine-specific and only the absence of a
+      // hang, plus exactly one afterEach, is being asserted.
+      const cases = [
+        // .svg extension skips the content-type check, so the load turns on
+        // whatever status the engine reports for file://.
+        ['./icon.svg', 'injects'],
+        // No extension, so the content-type check runs against whatever header
+        // the engine synthesises for a local file. Chromium sniffs text/plain,
+        // which the check allows, and injects; Firefox reports text/xml, which
+        // it rejects. Both are correct: the assertion is that it resolves once
+        // either way rather than hanging.
+        ['./icon-no-extension', 'either'],
+        // Missing file.
+        ['./does-not-exist.svg', 'errors'],
+      ]
+
+      // Read straight off the transport, so the table shows the two values the
+      // verdicts turn on rather than leaving them to be inferred.
+      const probe = (url) =>
+        new Promise((resolve) => {
+          const xhr = new XMLHttpRequest()
+          let seen = null
+          xhr.onreadystatechange = () => {
+            if (xhr.readyState === 2) {
+              seen = {
+                status: xhr.status,
+                contentType: xhr.getResponseHeader('Content-Type'),
+              }
+            }
+            if (xhr.readyState === 4) {
+              resolve(seen ?? { status: xhr.status, contentType: null, noHeaders: true })
+            }
+          }
+          xhr.onerror = () => resolve({ blocked: true })
+          try {
+            xhr.open('GET', url)
+            xhr.overrideMimeType('image/svg+xml')
+            xhr.send()
+          } catch (e) {
+            resolve({ blocked: true })
+          }
+        })
+
+      const run = async ([url, expected]) => {
+        const seen = await probe(url)
+
+        return new Promise((resolve) => {
+          host.innerHTML = ''
+          const el = document.createElement('div')
+          el.dataset.src = url
+          host.appendChild(el)
+
+          let calls = 0
+          let message = ''
+          let injected = false
+
+          inject(el, {
+            afterEach(error, svg) {
+              calls++
+              if (error) message = error.message
+              if (svg) injected = true
+            },
+            afterAll() {
+              // afterAll fires on the last afterEach, so a second call would
+              // land after it. The wait is what catches the double-callback.
+              setTimeout(() => {
+                const actual = injected
+                  ? 'injected'
+                  : message
+                    ? 'error'
+                    : 'nothing'
+                const outcomeOk =
+                  expected === 'injects'
+                    ? injected
+                    : expected === 'errors'
+                      ? !!message
+                      : actual !== 'nothing'
+
+                resolve({
+                  url,
+                  expected,
+                  actual,
+                  transport: seen.blocked
+                    ? 'blocked by the browser'
+                    : `status ${seen.status}, ${
+                        seen.noHeaders
+                          ? 'no readyState 2'
+                          : `Content-Type ${seen.contentType ?? '(none)'}`
+                      }`,
+                  calls,
+                  message,
+                  pass: outcomeOk && calls === 1,
+                })
+              }, 120)
+            },
+          })
+        })
+      }
+
+      ;(async () => {
+        const rows = []
+        for (const c of cases) rows.push(await run(c))
+        const failed = rows.filter((r) => !r.pass).length
+        const summary = document.getElementById('summary')
+        summary.textContent = failed ? `${failed} of ${rows.length} FAILED` : `all ${rows.length} passed`
+        summary.className = failed ? 'fail' : 'pass'
+        document.getElementById('out').innerHTML =
+          '<table><thead><tr><th>url</th><th>transport reports</th><th>expected</th><th>actual</th><th>afterEach calls</th><th>message</th><th>verdict</th></tr></thead><tbody>' +
+          rows.map((r) =>
+            `<tr class="${r.pass ? 'pass' : 'fail'}"><td>${r.url}</td><td>${r.transport}</td><td>${r.expected}</td><td>${r.actual}</td><td>${r.calls}</td><td>${r.message}</td><td>${r.pass ? 'PASS' : 'FAIL'}</td></tr>`,
+          ).join('') +
+          '</tbody></table>'
+      })()
+    </script>
+  </body>
+</html>

--- a/test/manual/file-protocol/probe.mjs
+++ b/test/manual/file-protocol/probe.mjs
@@ -1,0 +1,64 @@
+// Drives index.html over a real file:// load in each engine. No routing, no
+// server: the page reads sibling files from disk.
+//
+// A pre-check, not a substitute for the stock browsers. Playwright's builds lag
+// them and set their own preferences, and its webkit cannot lift the local file
+// restriction at all — which is the engine that matters most here.
+//
+//   node test/manual/file-protocol/probe.mjs
+import { chromium, firefox, webkit } from '@playwright/test'
+import path from 'node:path'
+import url from 'node:url'
+
+const here = path.dirname(url.fileURLToPath(import.meta.url))
+const pageUrl = url.pathToFileURL(path.join(here, 'index.html')).href
+
+// Chromium and WebKit block file:// -> file:// XHR at default settings, and
+// Playwright's webkit cannot be told otherwise, so those two runs report
+// failures by design. They are kept because they show what a user without the
+// relaxed setting sees, and because case 1 failing there is the evidence that
+// the flag is what the other runs are actually exercising. `blocked: true`
+// marks them so a real regression is still distinguishable at a glance.
+const engines = [
+  ['chromium', chromium, {}, { blocked: true }],
+  [
+    'chromium --allow-file-access-from-files',
+    chromium,
+    { args: ['--allow-file-access-from-files'] },
+    {},
+  ],
+  ['firefox', firefox, {}, {}],
+  ['webkit', webkit, {}, { blocked: true }],
+]
+
+for (const [name, type, launchOptions, { blocked }] of engines) {
+  const browser = await type.launch(launchOptions)
+  const page = await browser.newPage()
+  const consoleErrors = []
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text())
+  })
+  page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`))
+
+  await page.goto(pageUrl)
+  await page.waitForFunction(
+    () => !document.getElementById('summary').textContent.includes('running'),
+    null,
+    { timeout: 15000 },
+  )
+
+  const protocol = await page.evaluate(() => window.location.protocol)
+  const summary = await page.textContent('#summary')
+  const rows = await page.$$eval('#out tbody tr', (trs) =>
+    trs.map((tr) => [...tr.children].map((td) => td.textContent)),
+  )
+
+  const note = blocked
+    ? ' (local XHR blocked here by design — case 1 is expected to fail)'
+    : ''
+  console.log(`\n=== ${name} === protocol=${protocol} :: ${summary}${note}`)
+  for (const r of rows) console.log('  ' + r.join(' | '))
+  for (const e of consoleErrors) console.log('  console: ' + e)
+
+  await browser.close()
+}

--- a/test/manual/file-protocol/readystate-probe.mjs
+++ b/test/manual/file-protocol/readystate-probe.mjs
@@ -1,0 +1,63 @@
+// Why the extensionless case diverges by engine: records which readyStates a
+// file:// XHR reaches, and what Content-Type (if any) is reported at each one.
+//
+//   node test/manual/file-protocol/readystate-probe.mjs
+import { chromium, firefox, webkit } from '@playwright/test'
+import path from 'node:path'
+import url from 'node:url'
+
+const here = path.dirname(url.fileURLToPath(import.meta.url))
+const pageUrl = url.pathToFileURL(path.join(here, 'index.html')).href
+
+const engines = [
+  [
+    'chromium --allow-file-access-from-files',
+    chromium,
+    { args: ['--allow-file-access-from-files'] },
+  ],
+  ['firefox', firefox, {}],
+  ['webkit', webkit, {}],
+]
+
+const trace = (target) =>
+  new Promise((resolve) => {
+    const seen = []
+    const xhr = new XMLHttpRequest()
+    xhr.onreadystatechange = () => {
+      let header = null
+      let err = null
+      try {
+        header = xhr.getResponseHeader('Content-Type')
+      } catch (e) {
+        err = String(e)
+      }
+      seen.push({
+        readyState: xhr.readyState,
+        status: xhr.status,
+        contentType: header,
+        headerError: err,
+        responseXML: xhr.readyState === 4 ? xhr.responseXML !== null : null,
+      })
+      if (xhr.readyState === 4) resolve(seen)
+    }
+    xhr.onerror = () => resolve([...seen, { error: 'onerror' }])
+    try {
+      xhr.open('GET', target)
+      xhr.overrideMimeType('image/svg+xml')
+      xhr.send()
+    } catch (e) {
+      resolve([{ threw: String(e) }])
+    }
+  })
+
+for (const [name, type, launchOptions] of engines) {
+  const browser = await type.launch(launchOptions)
+  const page = await browser.newPage()
+  await page.goto(pageUrl)
+  console.log(`\n=== ${name} ===`)
+  for (const target of ['./icon.svg', './icon-no-extension']) {
+    const seen = await page.evaluate(trace, target)
+    console.log(`  ${target}: ${JSON.stringify(seen)}`)
+  }
+  await browser.close()
+}

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en-NZ">
+  <head>
+    <meta charset="utf-8" />
+    <title>svg-injector — real-server transport checks</title>
+    <script src="/svg-injector.iife.js"></script>
+    <style>
+      body { font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; padding: 2rem; max-width: 78rem; }
+      h1 { font-size: 1.2rem; }
+      table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+      th, td { border: 1px solid #bbb; padding: 0.35rem 0.6rem; text-align: left; vertical-align: top; }
+      th { background: #eee; font-size: 0.78rem; text-transform: uppercase; }
+      .pass { background: #e6f5e9; }
+      .fail { background: #fdeceb; }
+      .verdict { font-weight: bold; }
+      #summary { font-size: 1.05rem; font-weight: bold; margin-top: 1rem; }
+      #host { position: absolute; left: -9999px; }
+      td.msg { font-size: 0.82rem; color: #444; word-break: break-word; }
+    </style>
+  </head>
+  <body>
+    <h1>svg-injector — real-server transport checks</h1>
+    <p>
+      Each case runs against genuine response headers from
+      <code>server.mjs</code>, not Playwright route interception. Expected values
+      are derived from <code>src/make-ajax-request.ts</code> and
+      <code>src/load-svg-cached.ts</code>, so a deliberate change to either means
+      updating the expectation here alongside it.
+    </p>
+    <div id="summary">running…</div>
+    <div id="out"></div>
+    <div id="host"></div>
+
+    <script>
+      const inject = window.SVGInjector.SVGInjector
+      const host = document.getElementById('host')
+
+      // [label, url, options, expected]
+      // expected.ok      - injection succeeds
+      // expected.error   - substring the reported message must contain
+      // expected.calls   - how many times afterEach must fire (exactly-once accounting)
+      const cases = [
+        ['.svg, correct type', '/icon.svg', {}, { ok: true, calls: 1 }],
+        ['.svg, wrong type (bypass)', '/icon-wrong-type.svg', {}, { ok: true, calls: 1 }],
+        ['.svg, no Content-Type (bypass)', '/icon-no-type.svg', {}, { ok: true, calls: 1 }],
+        ['.svg via 302 redirect', '/redirect.svg', {}, { ok: true, calls: 1 }],
+        ['.svg, delayed 400ms', '/slow.svg', {}, { ok: true, calls: 1 }],
+
+        ['no ext, image/svg+xml', '/no-ext-svg', {}, { ok: true, calls: 1 }],
+        ['no ext, text/plain', '/no-ext-plain', {}, { ok: true, calls: 1 }],
+        ['no ext, type + params', '/no-ext-params', {}, { ok: true, calls: 1 }],
+        ['no ext, uppercase type', '/no-ext-uppercase', {}, { ok: true, calls: 1 }],
+
+        ['no ext, text/html', '/no-ext-html', {}, { error: 'Invalid content type: text/html', calls: 1 }],
+        ['no ext, no header', '/no-ext-no-header', {}, { error: 'Content type not found', calls: 1 }],
+        ['no ext, no media type', '/no-ext-no-mediatype', {}, { error: 'Content type not found', calls: 1 }],
+        ['no ext, malformed type', '/no-ext-malformed', {}, { error: 'Invalid content type: invalid', calls: 1 }],
+
+        // Rejecting the header aborts the request, and the abort re-enters the
+        // readystate handler. Real abort semantics are exactly what route
+        // interception cannot vouch for, so `calls: 1` is the point of these
+        // two rows: before the `settled` flag they reported twice.
+        ['no ext, text/html, cacheRequests:false', '/no-ext-html', { cacheRequests: false }, { error: 'Invalid content type: text/html', calls: 1 }],
+        ['no ext, no header, cacheRequests:false', '/no-ext-no-header', { cacheRequests: false }, { error: 'Content type not found', calls: 1 }],
+
+        ['404', '/missing.svg', {}, { error: 'Unable to load SVG file', calls: 1 }],
+        // Unparseable body: responseXML is null, so the older branch catches it
+        // before the status is ever considered.
+        ['500, unparseable body', '/server-error.svg', {}, { error: 'Unable to load SVG file', calls: 1 }],
+        // Parseable body with a non-200 status: the only route to this branch.
+        ['500, valid SVG body', '/svg-with-500.svg', {}, { error: 'There was a problem injecting the SVG: 500', calls: 1 }],
+        // Lowercase <!doctype is invalid XML, so this fails to parse outright.
+        ['200, HTML body at .svg URL', '/html-body.svg', {}, { error: 'Unable to load SVG file', calls: 1 }],
+        // Parses cleanly, but the root element is not <svg>. A body that fails
+        // to parse never reaches this branch, so the XML above has to be valid.
+        ['200, well-formed non-SVG XML', '/xml-not-svg.svg', {}, { error: 'Unable to parse SVG from response', calls: 1 }],
+
+        // The narrowing: v11 skipped the check because the whole URL contained
+        // ".svg". v12 matches the pathname, so this now needs a valid type.
+        ['.svg only in query string', '/render?file=logo.svg', {}, { error: 'Invalid content type: text/html', calls: 1 }],
+
+        // `open()` throws synchronously for a URL the parser rejects. The
+        // throw must be reported through afterEach, not escape the call.
+        ['URL the parser rejects', 'http://', {}, { error: '', calls: 1 }],
+      ]
+
+      const run = ([label, url, options, expected]) =>
+        new Promise((resolve) => {
+          host.innerHTML = ''
+          const el = document.createElement('div')
+          el.dataset.src = url
+          host.appendChild(el)
+
+          let calls = 0
+          let lastError = null
+          let injected = false
+
+          inject(el, {
+            ...options,
+            afterEach(error, svg) {
+              calls++
+              if (error) lastError = error.message
+              if (svg) injected = true
+            },
+            afterAll() {
+              // Give any stray second callback a chance to arrive before
+              // judging: firing twice is the failure mode being hunted.
+              setTimeout(() => {
+                const okCalls = calls === expected.calls
+                const okOutcome = expected.ok
+                  ? injected && !lastError
+                  : lastError !== null &&
+                    (expected.error === '' || lastError.includes(expected.error))
+                resolve({
+                  label,
+                  url,
+                  expected: expected.ok
+                    ? `inject, ${expected.calls} afterEach`
+                    : `"${expected.error || '(any error)'}", ${expected.calls} afterEach`,
+                  actual: `${injected ? 'injected' : lastError ? 'error' : 'nothing'}, ${calls} afterEach`,
+                  message: lastError ?? '',
+                  pass: okCalls && okOutcome,
+                })
+              }, 120)
+            },
+          })
+        })
+
+      // A failed load must not be cached. Left on the loading sentinel, the URL
+      // would park there forever: every later injection would wait on a
+      // response that had already arrived, and no refetch would be made. The
+      // entry is dropped instead, so a second injection hits the server again.
+      // Counted through /hits, because nothing observable on the page
+      // distinguishes a refetch from a cache hit that never resolves.
+      const refetchCheck = async () => {
+        const url = '/xml-not-svg.svg'
+        const before = (await (await fetch('/hits')).json())[url] ?? 0
+
+        for (let i = 0; i < 2; i++) {
+          await new Promise((resolve) => {
+            host.innerHTML = ''
+            const el = document.createElement('div')
+            el.dataset.src = url
+            host.appendChild(el)
+            inject(el, { afterAll: () => setTimeout(resolve, 60) })
+          })
+        }
+
+        const after = (await (await fetch('/hits')).json())[url] ?? 0
+        const requests = after - before
+        return {
+          label: 'failed load is not cached (refetches)',
+          url,
+          expected: '2 server requests',
+          actual: `${requests} server requests`,
+          message: requests < 2 ? 'second injection was served from a stale cache entry' : '',
+          pass: requests === 2,
+        }
+      }
+
+      ;(async () => {
+        const rows = []
+        for (const testCase of cases) rows.push(await run(testCase))
+        rows.push(await refetchCheck())
+
+        const failed = rows.filter((r) => !r.pass).length
+        document.getElementById('summary').textContent = failed
+          ? `${failed} of ${rows.length} FAILED`
+          : `all ${rows.length} passed`
+        document.getElementById('summary').className = failed ? 'fail' : 'pass'
+
+        document.getElementById('out').innerHTML =
+          '<table><thead><tr><th>case</th><th>url</th><th>expected</th><th>actual</th><th>message</th><th>verdict</th></tr></thead><tbody>' +
+          rows
+            .map(
+              (r) =>
+                `<tr class="${r.pass ? 'pass' : 'fail'}"><td>${r.label}</td><td>${r.url}</td><td>${r.expected}</td><td>${r.actual}</td><td class="msg">${r.message}</td><td class="verdict">${r.pass ? 'PASS' : 'FAIL'}</td></tr>`,
+            )
+            .join('') +
+          '</tbody></table>'
+      })()
+    </script>
+  </body>
+</html>

--- a/test/manual/server.mjs
+++ b/test/manual/server.mjs
@@ -1,0 +1,124 @@
+// A real HTTP server for checking make-ajax-request.ts by hand.
+//
+// The Playwright suite intercepts every request, so real-server behaviour is
+// simulated there. This serves genuine headers, genuine 404s and a genuine
+// redirect so the transport can be checked against the real thing. See
+// test/manual/README.md.
+//
+//   npm run build
+//   node test/manual/server.mjs
+//   open http://localhost:4180/
+import { createServer } from 'node:http'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repo = join(here, '..', '..')
+
+// tsdown writes this from src/, so the check always runs against the current
+// build. Say so rather than letting readFileSync report a bare ENOENT.
+const bundlePath = join(repo, 'test/dist/svg-injector.iife.js')
+if (!existsSync(bundlePath)) {
+  console.error(`${bundlePath} is missing. Run \`npm run build\` first.`)
+  process.exit(1)
+}
+
+const svg = readFileSync(join(repo, 'test/fixtures/dashboard.svg'), 'utf8')
+const bundle = readFileSync(bundlePath, 'utf8')
+const page = readFileSync(join(here, 'index.html'), 'utf8')
+// Lowercase `<!doctype` is not valid XML, so this fails to parse outright and
+// reports "Unable to load SVG file" rather than reaching the non-SVG-root
+// branch below.
+const html = '<!doctype html><html><body><p>not an svg</p></body></html>'
+
+// Well-formed XML whose root element is not <svg>. It needs a body that parses
+// cleanly, otherwise it falls into the unparseable branch above and never
+// reaches the "Unable to parse SVG from response" one.
+const xmlNotSvg = '<?xml version="1.0"?><error><message>nope</message></error>'
+
+// Counts requests per path so the cache-drop behaviour can be checked: a
+// failed load must not be cached, so a second injection refetches.
+const hits = {}
+
+// path -> [status, headers, body]. `null` for a header value omits it.
+const routes = {
+  '/': [200, { 'Content-Type': 'text/html' }, page],
+  '/svg-injector.iife.js': [200, { 'Content-Type': 'text/javascript' }, bundle],
+
+  // .svg extension: the content-type check is skipped entirely.
+  '/icon.svg': [200, { 'Content-Type': 'image/svg+xml' }, svg],
+  '/icon-wrong-type.svg': [200, { 'Content-Type': 'text/html' }, svg],
+  '/icon-no-type.svg': [200, { 'Content-Type': null }, svg],
+
+  // No extension: the content-type check applies.
+  '/no-ext-svg': [200, { 'Content-Type': 'image/svg+xml' }, svg],
+  '/no-ext-plain': [200, { 'Content-Type': 'text/plain' }, svg],
+  '/no-ext-params': [
+    200,
+    { 'Content-Type': 'image/svg+xml; charset=utf-8' },
+    svg,
+  ],
+  '/no-ext-uppercase': [200, { 'Content-Type': 'IMAGE/SVG+XML' }, svg],
+  '/no-ext-html': [200, { 'Content-Type': 'text/html' }, svg],
+  '/no-ext-no-header': [200, { 'Content-Type': null }, svg],
+  '/no-ext-no-mediatype': [200, { 'Content-Type': '; charset=utf-8' }, svg],
+  '/no-ext-malformed': [200, { 'Content-Type': 'invalid' }, svg],
+
+  // Failure shapes.
+  '/missing.svg': [404, { 'Content-Type': 'text/html' }, 'not found'],
+  // Unparseable body, so responseXML is null and the first branch catches it.
+  '/server-error.svg': [500, { 'Content-Type': 'text/html' }, 'boom'],
+  // A parseable body with a non-200 status is the only way to reach the
+  // "There was a problem injecting the SVG" branch.
+  '/svg-with-500.svg': [500, { 'Content-Type': 'image/svg+xml' }, svg],
+  '/html-body.svg': [200, { 'Content-Type': 'image/svg+xml' }, html],
+  '/xml-not-svg.svg': [200, { 'Content-Type': 'image/svg+xml' }, xmlNotSvg],
+
+  // The bypass matches the pathname, not the whole URL: .svg appears only in
+  // the query string here, so the content-type check applies.
+  '/render': [200, { 'Content-Type': 'text/html' }, svg],
+}
+
+createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost')
+  const path = url.pathname
+  hits[path] = (hits[path] ?? 0) + 1
+
+  if (path === '/hits') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(hits))
+    return
+  }
+
+  if (path === '/redirect.svg') {
+    res.writeHead(302, { Location: '/icon.svg' })
+    res.end()
+    return
+  }
+
+  if (path === '/slow.svg') {
+    setTimeout(() => {
+      res.writeHead(200, { 'Content-Type': 'image/svg+xml' })
+      res.end(svg)
+    }, 400)
+    return
+  }
+
+  const route = routes[path]
+  if (!route) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' })
+    res.end('no route')
+    return
+  }
+
+  const [status, headers, body] = route
+  const sent = {}
+  for (const [name, value] of Object.entries(headers)) {
+    if (value !== null) sent[name] = value
+  }
+  res.writeHead(status, sent)
+  res.end(body)
+}).listen(4180, () => {
+  console.log('Transport checks on http://localhost:4180/')
+})


### PR DESCRIPTION
`AGENTS.md` names the Playwright suite's mocking as its blind spot: `test/playwright/test-utils.ts` routes every request, so real-server and `file://` behaviour is simulated, and a change to `make-ajax-request.ts` needs checking by hand before it is believed. That instruction had nothing behind it — whoever next touched the file had to build a probe from scratch, which is what the v12 pre-merge review did and what the cache-hit work did before it.

This commits the harness that review built, so the instruction is runnable.

## What lands

`test/manual/`:

- `server.mjs` — a plain node server on 4180 serving headers a static server cannot be made to send: a missing `Content-Type`, a header with no media type, a malformed one, a 302, a delayed response, and a `/hits` endpoint that counts requests per path.
- `index.html` — 22 cases plus a refetch check. Each asserts the outcome **and** the number of `afterEach` calls, with expected values derived from `src/make-ajax-request.ts` and `src/load-svg-cached.ts`.
- `file-protocol/` — the three `file://` cases, plus two Playwright probes as a pre-check.
- `README.md` — how to run it, why each awkward case is there, and the last recorded result.

`AGENTS.md` gains a pointer from the paragraph that states the blind spot.

## Deliberately not automated

The value is that it uses a real server and a real `file://` load. Wiring it into CI would mean mocking it, which is the thing it exists to escape. `playwright.config.ts` already matches `**/*.test.ts` only, so `npm test` does not see the directory, and `tsconfig.json` has no `allowJs`, so `check:types` does not either. The only config change needed was adding `test/manual/**/*.mjs` to the existing `no-console` exemption.

## No vendored bundle

The plan assumed `file-protocol/` would need a gitignored copy of `test/dist/svg-injector.iife.js`, since ES modules do not load over `file://`. It does not: the IIFE is a *classic* script, and a classic script loads from a sibling directory over `file://` in every engine. The page reads `../../dist/svg-injector.iife.js`, which `npm run build` writes, so the check always runs against the current build and there is no artifact to remember to refresh.

## Cases worth understanding

| Case | Why it is here |
| --- | --- |
| `cacheRequests: false` with a rejected content type | Rejecting the header aborts, and the abort re-enters the readystate handler. Route interception does not reproduce that second event, so this is the only place the exactly-once accounting is really tested. |
| 200 with well-formed non-SVG XML | Reaches the non-SVG-root branch, which needs a body that parses cleanly. A lowercase `<!doctype` fails XML parsing outright and lands in the unparseable branch instead, so both bodies are served. |
| Same URL injected twice after a parse failure | That a failed load is not cached. Counted through `/hits`, because nothing on the page distinguishes a refetch from a cache entry parked on the loading sentinel. |
| `.svg` only in the query string | The extension bypass matches the pathname, not the whole URL, against a genuine server header. |
| 500 with an unparseable body vs 500 with a valid SVG body | Two different branches. `responseXML === null` is tested before the status, so only a parseable body reaches `There was a problem injecting the SVG`. |

## Verification

- 23/23 HTTP in real Chrome 151.
- 23/23 HTTP in all three Playwright engines against the real server.
- 3/3 `file://` in Playwright chromium with `--allow-file-access-from-files` and in firefox. Stock chromium and Playwright's webkit cannot lift the local-file restriction, so their expected failures are now labelled in `probe.mjs` output.
- `npm test` green: 360 suite tests, 12 example tests.

The stock-Safari `file://` leg has not been re-run since the move. The only change that could affect it is the relative script path, which chromium and firefox both exercised.

## Still open

Whether the HTTP half is worth promoting to a real Playwright project served by a fixture web server, leaving only `file://` manual. Not decided here.