### PR TITLE
Add an error-handling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Each name links to the example source, and the sandbox column opens it on CodeSa
 | [API Usage](https://github.com/tanem/svg-injector/tree/master/examples/api-usage)               | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/api-usage)        |
 | [Basic Usage](https://github.com/tanem/svg-injector/tree/master/examples/basic-usage)           | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/basic-usage)      |
 | [Data URL Usage](https://github.com/tanem/svg-injector/tree/master/examples/data-url-usage)     | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/data-url-usage)   |
+| [Error Handling](https://github.com/tanem/svg-injector/tree/master/examples/error-handling)     | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/error-handling)   |
 | [IRI Renumeration](https://github.com/tanem/svg-injector/tree/master/examples/iri-renumeration) | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/iri-renumeration) |
 | [Sprite Usage](https://github.com/tanem/svg-injector/tree/master/examples/sprite-usage)         | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/sprite-usage)     |
 

--- a/examples/error-handling/README.md
+++ b/examples/error-handling/README.md
@@ -1,0 +1,57 @@
+# Error Handling
+
+Three placeholders, two of which cannot be injected. Both failures come from a real static server rather than a mocked response: `missing.svg` is not in `public/`, and `markup.html` is a valid SVG document saved with an extension that makes every server send it as `text/html`.
+
+## What it shows
+
+- `afterEach` fires once per element on every path, with an `Error` for the two that failed and the injected `<svg>` for the one that succeeded.
+- The error messages name their cause: `Unable to load SVG file: missing.svg` and `Invalid content type: text/html`. The content type is checked as soon as the response headers arrive, so a rejected response never has its body parsed.
+- `afterAll` receives the number of elements _processed_, failures included, so it is `3` here while only one SVG reached the page. Count the `afterEach` calls whose `error` is `null` for the number injected.
+- A failed injection leaves its placeholder in the document. Nothing is removed, so there is somewhere to put a fallback.
+
+See the [API docs](https://github.com/tanem/svg-injector#api) for the full callback semantics.
+
+## Under `npm run dev`
+
+Vite's dev server answers an unmatched path with `index.html` and a 200 rather than a 404, so the first case reports `Unable to parse SVG from response: missing.svg` there instead of `Unable to load SVG file: missing.svg`. Both are the same failure seen from different sides: the URL ends `.svg`, which skips the content-type check, so the HTML body is only rejected once it fails to parse as an SVG document. `npm run build && npm run preview` serves the 404 and gives the first message.
+
+## Usage
+
+```js
+import { SVGInjector } from '@tanem/svg-injector'
+
+SVGInjector(document.getElementsByClassName('inject-me'), {
+  afterEach(error, svg) {
+    if (error) {
+      console.error(error)
+      return
+    }
+    console.log(`injected ${svg.outerHTML}`)
+  },
+  afterAll(elementsLoaded) {
+    console.log(`processed ${elementsLoaded} elements`)
+  },
+})
+```
+
+Report the error and return. A throw from `afterEach` escapes as an uncaught exception; the accounting still completes and the rest of the collection still injects, but the page has an unhandled error in it either way.
+
+## Matching an error back to its element
+
+`afterEach` is called with the error and, on success, the injected SVG. It is not called with the placeholder, and only one of the two messages above names the URL, so a collection cannot pair its failures with their elements from the callback arguments alone.
+
+The example works around it in `afterAll`: an element that injected has been replaced by its SVG, which leaves the failures as the only placeholders still in the document.
+
+```js
+const placeholders = Array.from(document.getElementsByClassName('inject-me'))
+
+SVGInjector(placeholders, {
+  afterAll() {
+    for (const el of placeholders.filter((el) => el.isConnected)) {
+      // el failed
+    }
+  },
+})
+```
+
+That waits for the whole collection. To react per element as soon as it fails, call `SVGInjector` once per placeholder instead and let the closure hold the element. `afterAll` then reports `1` per call rather than the collection total.

--- a/examples/error-handling/index.html
+++ b/examples/error-handling/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SVGInjector Error Handling Example</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 640px;
+        margin: 2rem auto;
+        color: #1e293b;
+      }
+      h1 {
+        font-size: 1.25rem;
+      }
+      h2 {
+        font-size: 0.875rem;
+        margin-bottom: 0.25rem;
+      }
+      p {
+        font-size: 0.875rem;
+        line-height: 1.6;
+        color: #475569;
+      }
+      .cases {
+        display: flex;
+        gap: 1.5rem;
+        margin: 1.5rem 0;
+      }
+      .case {
+        flex: 1;
+      }
+      .case p {
+        margin-top: 0;
+      }
+      /* Two lines at this column width, so the three placeholders below start
+         at the same height whichever descriptions are wrapped. */
+      .case .note {
+        min-height: 2.8rem;
+      }
+      .fallback {
+        display: inline-block;
+        padding: 0.5rem;
+        border: 1px dashed #b91c1c;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        color: #b91c1c;
+      }
+      #reported {
+        padding-left: 1.25rem;
+      }
+      #reported li {
+        font-family: ui-monospace, monospace;
+        font-size: 0.75rem;
+        color: #b91c1c;
+      }
+      #processed {
+        font-family: ui-monospace, monospace;
+        font-size: 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Error Handling</h1>
+    <p>
+      Three placeholders, two of which cannot be injected. Every element is
+      reported to <code>afterEach</code>, whether it succeeded or failed, and
+      <code>afterAll</code> runs once all three have been processed.
+    </p>
+    <div class="cases">
+      <div class="case">
+        <h2>Missing file</h2>
+        <p class="note">Nothing is served at that path.</p>
+        <div class="inject-me" data-src="missing.svg"></div>
+      </div>
+      <div class="case">
+        <h2>Wrong content type</h2>
+        <p class="note">An SVG document served as <code>text/html</code>.</p>
+        <div class="inject-me" data-src="markup.html"></div>
+      </div>
+      <div class="case">
+        <h2>Success</h2>
+        <p class="note">A plain SVG file, for contrast.</p>
+        <div class="inject-me" data-src="icon.svg"></div>
+      </div>
+    </div>
+    <h2>Reported to <code>afterEach</code></h2>
+    <ul id="reported"></ul>
+    <p id="processed"></p>
+    <script type="module" src="index.ts"></script>
+  </body>
+</html>

--- a/examples/error-handling/index.ts
+++ b/examples/error-handling/index.ts
@@ -1,0 +1,43 @@
+import { SVGInjector } from '@tanem/svg-injector'
+
+// Snapshotted before the call, because `getElementsByClassName` is live: each
+// placeholder that injects is replaced by its SVG and drops out of the
+// collection, so a later read would only see the failures.
+const placeholders = Array.from(document.getElementsByClassName('inject-me'))
+
+const reported = document.getElementById('reported')!
+const processed = document.getElementById('processed')!
+
+SVGInjector(placeholders, {
+  afterEach(error) {
+    if (!error) {
+      return
+    }
+
+    // Reported rather than thrown: a throw from here escapes as an uncaught
+    // exception and leaves the rest of the collection to finish without it.
+    const item = document.createElement('li')
+    item.textContent = error.message
+    reported.append(item)
+  },
+  afterAll(elementsLoaded) {
+    // `afterEach` names the failure but not the element it belongs to, so the
+    // fallbacks are placed here instead: an element that injected has been
+    // replaced by its SVG, which leaves the failures as the only placeholders
+    // still in the document.
+    const failed = placeholders.filter((el) => el.isConnected)
+
+    for (const el of failed) {
+      const fallback = document.createElement('p')
+      fallback.className = 'fallback'
+      fallback.textContent = `Could not load ${el.getAttribute('data-src')}`
+      el.replaceWith(fallback)
+    }
+
+    // `elementsLoaded` counts every element processed, the failures included,
+    // so it is 3 here rather than the 1 that reached the page.
+    processed.textContent = `afterAll(${elementsLoaded}): ${
+      elementsLoaded - failed.length
+    } injected, ${failed.length} failed`
+  },
+})

--- a/examples/error-handling/package.json
+++ b/examples/error-handling/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "error-handling",
+  "version": "1.0.0",
+  "description": "SVGInjector Error Handling Example",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "@tanem/svg-injector": "latest"
+  },
+  "keywords": [
+    "@tanem/svg-injector"
+  ],
+  "devDependencies": {
+    "vite": "^8.2.0"
+  }
+}

--- a/examples/error-handling/public/icon.svg
+++ b/examples/error-handling/public/icon.svg
@@ -1,0 +1,16 @@
+<svg
+  height="48"
+  viewBox="0 0 48 48"
+  width="48"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle cx="24" cy="24" fill="none" r="20" stroke="#15803d" stroke-width="4" />
+  <path
+    d="M 15 24 l 7 7 l 12 -14"
+    fill="none"
+    stroke="#15803d"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="4"
+  />
+</svg>

--- a/examples/error-handling/public/markup.html
+++ b/examples/error-handling/public/markup.html
@@ -1,0 +1,14 @@
+<svg
+  height="48"
+  viewBox="0 0 48 48"
+  width="48"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <!--
+    A valid SVG document, deliberately saved with a .html extension. Static
+    servers pick the content type from the extension, so this is sent as
+    text/html and the injector rejects it before its body arrives. Nothing
+    here is ever injected.
+  -->
+  <rect fill="#b91c1c" height="40" rx="4" width="40" x="4" y="4" />
+</svg>

--- a/examples/error-handling/tsconfig.json
+++ b/examples/error-handling/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "esnext",
+    "target": "es2020",
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "lib": [
+      "es2020",
+      "dom"
+    ],
+    "rootDir": ".",
+    "moduleResolution": "bundler"
+  },
+  "files": ["index.ts"]
+}

--- a/examples/error-handling/vite.config.js
+++ b/examples/error-handling/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  // The built examples are served from a shared static server under
+  // <example>/dist/, so asset URLs have to be relative to the page.
+  base: './',
+})

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -11,6 +11,7 @@ const examples = [
   'api-usage',
   'basic-usage',
   'data-url-usage',
+  'error-handling',
   'iri-renumeration',
   'sprite-usage',
 ]

--- a/test/examples.test.ts
+++ b/test/examples.test.ts
@@ -27,6 +27,10 @@ const examples = [
     expectedSvgCount: 6,
   },
   {
+    name: 'error-handling',
+    expectedSvgCount: 1,
+  },
+  {
     name: 'iri-renumeration',
     expectedSvgCount: 3,
   },
@@ -81,6 +85,43 @@ test('data-url-usage: the bundler-inlined icon is injected from a data URL', asy
     /^data:image\/svg\+xml[,;]/,
   )
   await expect(injected.locator('path')).toHaveCount(1)
+})
+
+// The only example whose failures come from a real static server rather than
+// from a fixture override or a Playwright route: `missing.svg` is absent from
+// `public/`, and `markup.html` is an SVG document that any server sends as
+// `text/html`. Both messages are asserted verbatim, so a change to either
+// shows up here as well as in the library suite.
+test('error-handling: failures report verbatim and render a fallback', async ({
+  page,
+}) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', (err) => pageErrors.push(err.message))
+
+  await page.goto('/error-handling/dist/')
+
+  // Sorted, because the two requests fail in whichever order they finish.
+  await expect
+    .poll(async () =>
+      (await page.locator('#reported li').allTextContents()).sort(),
+    )
+    .toEqual([
+      'Invalid content type: text/html',
+      'Unable to load SVG file: missing.svg',
+    ])
+
+  await expect(page.locator('.fallback')).toHaveText([
+    'Could not load missing.svg',
+    'Could not load markup.html',
+  ])
+
+  // The count covers processed elements, failures included.
+  await expect(page.locator('#processed')).toHaveText(
+    'afterAll(3): 1 injected, 2 failed',
+  )
+  await expect(page.locator('svg.injected-svg')).toHaveCount(1)
+
+  expect(pageErrors).toEqual([])
 })
 
 test('api-usage: beforeEach applies stroke attribute', async ({ page }) => {


### PR DESCRIPTION
Adds `examples/error-handling`, the sixth example. The other five all demonstrate success paths, while v12's headline work was error behaviour: callbacks that fire on every path, errors that name their cause. None of that was visible anywhere a reader or CI could see it.

Both failures come from a real static server rather than a mocked response. `missing.svg` is not in `public/` and 404s. `markup.html` is a valid SVG document saved with an extension that makes every server send it as `text/html`, so it exercises the content-type check against a genuine header. A third placeholder loads normally, for contrast. The page renders the `afterAll` count, which is 3 while only one SVG reached the page.

The suite asserts both messages verbatim, so a future change to either shows up here as well as in the library suite.

### Fallbacks are placed in `afterAll`, not `afterEach`

`afterEach` receives `(error, svg)` and nothing else. On failure there is no SVG, and `Invalid content type: text/html` does not name its URL, so nothing in the callback identifies which placeholder failed. What does work: an element that injected has been replaced by its SVG, which leaves the failures as the only placeholders still connected to the document.

The example sweeps for those in `afterAll`, and its README covers the alternative — one `SVGInjector` call per element correlates exactly and reports immediately, at the cost of `afterAll` reporting 1 per call rather than the collection total. That is what `@tanem/react-svg` does, which is why this has never surfaced there.

### `npm run dev` reports the first case differently

Vite's dev server answers an unmatched path with `index.html` and a 200 rather than a 404, so under `npm run dev` the missing file reports `Unable to parse SVG from response: missing.svg` instead of `Unable to load SVG file: missing.svg`. It is the same failure seen one layer later: the URL ends `.svg`, which skips the content-type check, so the HTML body is only rejected once it fails to parse as an SVG document. The example README states this. The suite runs against the build, which 404s.

### Verification

`npm test` green: `check:format`, `check:types`, `lint`, `build` (publint, attw), `size` 4.26 kB ESM / 4.30 kB CJS against the 5.5 kB budget, 360 library tests across chromium, firefox and webkit, then six examples built against a fresh `npm pack` and 14 example tests.

Also confirmed in real Chrome against the built page served over HTTP: one icon injected, both fallbacks rendered, both messages verbatim, `afterAll(3): 1 injected, 2 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)