### PR TITLE
Add a no-bundler example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,13 @@ built against the local library first. Any SVG the injector fetches at runtime
 has to live in `<example>/public/`, because `data-src` is an opaque string to
 the bundler and nothing links it.
 
+`no-bundler` is the exception, and has to be: Vite bundles every
+`<script type="module">` in `index.html`, `public/` included, so a Vite build
+would replace the module import that is the whole point of it. Its `build.js`
+copies the page and `dist/svg-injector.mjs` into `dist/` instead. All the
+harness needs from an example is an `npm run build` that fills
+`<example>/dist/`.
+
 ## Conventions
 
 - One default export per module in `src/`, apart from `index.ts` (barrel) and

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,7 +12,7 @@ Details relating to major changes that aren't presently in `CHANGELOG.md`, due t
 
 - Removed the UMD builds. `dist/svg-injector.umd.development.js` and `dist/svg-injector.umd.production.js` are no longer published, so a plain `<script src>` tag no longer defines `window.SVGInjector`. The CommonJS and ES module builds remain, under new filenames: see the packaging entry below.
 
-  Script tag users have two options. Load the ES module build from an ESM CDN:
+  Script tag users have three options. Load the ES module build from an ESM CDN:
 
   ```html
   <script type="module">
@@ -21,6 +21,8 @@ Details relating to major changes that aren't presently in `CHANGELOG.md`, due t
     SVGInjector(document.getElementById('inject-me'))
   </script>
   ```
+
+  Or self-host `dist/svg-injector.mjs` and import it by URL. The [No Bundler](https://github.com/tanem/svg-injector/tree/master/examples/no-bundler) example is a worked version of that, and [README.md](README.md#without-a-bundler) covers both forms.
 
   Or stay on v11, which keeps the UMD builds:
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Each name links to the example source, and the sandbox column opens it on CodeSa
 | [Error Handling](https://github.com/tanem/svg-injector/tree/master/examples/error-handling)     | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/error-handling)   |
 | [Eval Scripts](https://github.com/tanem/svg-injector/tree/master/examples/eval-scripts)         | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/eval-scripts)     |
 | [IRI Renumeration](https://github.com/tanem/svg-injector/tree/master/examples/iri-renumeration) | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/iri-renumeration) |
+| [No Bundler](https://github.com/tanem/svg-injector/tree/master/examples/no-bundler)             | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/no-bundler)       |
 | [Sprite Usage](https://github.com/tanem/svg-injector/tree/master/examples/sprite-usage)         | [Open](https://codesandbox.io/p/devbox/github/tanem/svg-injector/tree/master/examples/sprite-usage)     |
 
 ## Installation
@@ -209,6 +210,30 @@ $ npm install @tanem/svg-injector
 ```
 
 The package ships an ES module and a CommonJS build behind an `exports` map, with type declarations for each, and has no runtime dependencies.
+
+### Without a bundler
+
+There is no UMD build and no `window.SVGInjector`: v11 had both and 12.0.0 dropped them. A page with no build step loads the ES module directly instead, either from a CDN:
+
+```html
+<script type="module">
+  import { SVGInjector } from 'https://esm.sh/@tanem/svg-injector'
+
+  SVGInjector(document.getElementById('inject-me'))
+</script>
+```
+
+or from a copy of `dist/svg-injector.mjs` served alongside the page:
+
+```html
+<script type="module">
+  import { SVGInjector } from './svg-injector.mjs'
+
+  SVGInjector(document.getElementById('inject-me'))
+</script>
+```
+
+Either way the specifier is a URL. A bare specifier such as `'@tanem/svg-injector'` needs a bundler or an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) to resolve. The [No Bundler](https://github.com/tanem/svg-injector/tree/master/examples/no-bundler) example is a worked version of the second form.
 
 > ⚠️This library is tested against current Chromium, Firefox and WebKit via Playwright. A browser is supported if the suite covers it.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,7 +56,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['scripts/**/*.js', 'examples/**/*.ts'],
+    files: ['scripts/**/*.js', 'examples/**/*.{js,ts}'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
       'no-console': 'off',

--- a/examples/no-bundler/README.md
+++ b/examples/no-bundler/README.md
@@ -1,0 +1,56 @@
+# No Bundler
+
+A static `index.html` that loads the library with a `<script type="module">` tag and injects an SVG. No bundler, no import of a package name, no `window.SVGInjector`.
+
+## Why this exists
+
+v11 published UMD builds, so `<script src="…/svg-injector.umd.production.js">` defined `window.SVGInjector` and a page needed nothing else. 12.0.0 removed them. Script tag users have two replacements, and this example is the second one.
+
+### Load the ES module from a CDN
+
+```html
+<script type="module">
+  import { SVGInjector } from 'https://esm.sh/@tanem/svg-injector'
+
+  SVGInjector(document.getElementById('inject-me'))
+</script>
+```
+
+One line, nothing to host. It puts a third party in the load path of your page, so pin the version if that matters to you.
+
+### Self-host `dist/svg-injector.mjs`
+
+What this example does. Copy the file out of the installed package and serve it alongside the page:
+
+```html
+<script type="module">
+  import { SVGInjector } from './svg-injector.mjs'
+
+  SVGInjector(document.getElementById('inject-me'))
+</script>
+```
+
+The import specifier is a URL, not a package name. A bare specifier such as `'@tanem/svg-injector'` needs a bundler or an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) to resolve, and a page with neither fails on it.
+
+## Running it
+
+`npm run build` copies `index.html`, `svg.svg` and the library into `dist/`, and `npm start` serves that directory. There is no Vite config, unlike the other examples: Vite bundles every `<script type="module">` in `index.html`, so the built page would load a chunk instead of the module this example exists to demonstrate. A file copy is what a self-hosting consumer does anyway.
+
+Two details of that copy worth carrying into your own build:
+
+- The library file is read from `node_modules/@tanem/svg-injector/dist/svg-injector.mjs` by path. The package's `exports` map makes every path inside it private apart from the root entry and `package.json`, so the file cannot be reached by specifier.
+- `svg-injector.mjs` ends with a `sourceMappingURL` comment, so `svg-injector.mjs.map` is copied with it. Without the map, devtools requests a file that isn't there.
+
+## Also worth knowing
+
+- The library ships no runtime dependencies, so the one file is the whole thing. There is nothing else to resolve at load time.
+- The published build is es2019. A browser old enough to need a transpiled build cannot parse the module in the first place, and no polyfill changes that.
+- SVGs are fetched at runtime over `XMLHttpRequest`, relative to the page. `data-src="svg.svg"` resolves against the document, exactly as it would with a bundler.
+
+## Usage
+
+```js
+import { SVGInjector } from './svg-injector.mjs'
+
+SVGInjector(document.getElementById('inject-me'))
+```

--- a/examples/no-bundler/build.js
+++ b/examples/no-bundler/build.js
@@ -1,0 +1,43 @@
+// The other examples are Vite apps. This one is not, because Vite bundles
+// every `<script type="module">` it finds in `index.html` — including one whose
+// src is served verbatim from `public/` — and the built page would then load a
+// chunk rather than the module the example exists to demonstrate.
+//
+// So the build is a file copy: the page and its SVG go into dist/ untouched,
+// and the library's ES module build is copied in beside them. That is also what
+// a self-hosting consumer does, which is the point.
+import fs from 'node:fs'
+import path from 'node:path'
+
+const exampleDir = import.meta.dirname
+const distDir = path.join(exampleDir, 'dist')
+
+const pageFiles = ['index.html', 'svg.svg']
+
+// Reached by path rather than by `import.meta.resolve`: the package's exports
+// map makes every path inside it private apart from the root entry and
+// `package.json`, so `dist/svg-injector.mjs` cannot be resolved by specifier.
+// The `.map` goes with it because the `.mjs` ends with a `sourceMappingURL`
+// comment, and without it devtools requests a file that isn't there.
+const libDir = path.join(
+  exampleDir,
+  'node_modules',
+  '@tanem',
+  'svg-injector',
+  'dist',
+)
+const libFiles = ['svg-injector.mjs', 'svg-injector.mjs.map']
+
+fs.rmSync(distDir, { force: true, recursive: true })
+fs.mkdirSync(distDir)
+
+for (const [dir, files] of [
+  [exampleDir, pageFiles],
+  [libDir, libFiles],
+]) {
+  for (const file of files) {
+    fs.copyFileSync(path.join(dir, file), path.join(distDir, file))
+  }
+}
+
+console.log(`Copied ${pageFiles.length + libFiles.length} files into dist/.`)

--- a/examples/no-bundler/index.html
+++ b/examples/no-bundler/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SVGInjector No Bundler Example</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 640px;
+        margin: 2rem auto;
+        color: #1e293b;
+      }
+      h1 {
+        font-size: 1.25rem;
+      }
+      p {
+        font-size: 0.875rem;
+        line-height: 1.6;
+        color: #475569;
+      }
+      pre {
+        font-size: 0.75rem;
+        line-height: 1.5;
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 4px;
+        padding: 0.75rem;
+        overflow-x: auto;
+      }
+      #inject-me {
+        margin: 1.5rem 0;
+      }
+      #status,
+      #global {
+        font-family: ui-monospace, monospace;
+        font-size: 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>No Bundler</h1>
+    <p>
+      Nothing on this page is bundled. It is served as a static file and loads
+      the library with a <code>&lt;script type="module"&gt;</code> tag, from a
+      copy of <code>dist/svg-injector.mjs</code> sitting next to
+      <code>index.html</code>:
+    </p>
+    <pre>&lt;script type="module"&gt;
+  import { SVGInjector } from './svg-injector.mjs'
+
+  SVGInjector(document.getElementById('inject-me'))
+&lt;/script&gt;</pre>
+    <div id="inject-me" data-src="svg.svg"></div>
+    <p id="status">Injecting&hellip;</p>
+    <p id="global"></p>
+    <p>
+      There is no <code>window.SVGInjector</code>. v11 defined one through its
+      UMD builds, which 12.0.0 removed; an ES module exports its bindings to
+      whatever imports it and puts nothing on the global object.
+    </p>
+
+    <!-- The specifier is a URL, not a package name. A bare specifier such as
+         '@tanem/svg-injector' needs either a bundler or an import map to
+         resolve, and this page has neither. -->
+    <script type="module">
+      import { SVGInjector } from './svg-injector.mjs'
+
+      document.getElementById('global').textContent =
+        `typeof window.SVGInjector === '${typeof window.SVGInjector}'`
+
+      SVGInjector(document.getElementById('inject-me'), {
+        afterEach(error) {
+          document.getElementById('status').textContent = error
+            ? `Injection failed: ${error.message}`
+            : 'Injected from ./svg-injector.mjs'
+        },
+      })
+    </script>
+  </body>
+</html>

--- a/examples/no-bundler/package.json
+++ b/examples/no-bundler/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "no-bundler",
+  "version": "1.0.0",
+  "description": "SVGInjector No Bundler Example",
+  "type": "module",
+  "scripts": {
+    "build": "node build.js",
+    "dev": "npm run start",
+    "preview": "serve dist --no-clipboard",
+    "start": "npm run build && serve dist --no-clipboard"
+  },
+  "dependencies": {
+    "@tanem/svg-injector": "latest"
+  },
+  "keywords": [
+    "@tanem/svg-injector"
+  ],
+  "devDependencies": {
+    "serve": "^14.2.6"
+  }
+}

--- a/examples/no-bundler/svg.svg
+++ b/examples/no-bundler/svg.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="30" height="30" stroke="black" fill="transparent" stroke-width="5" />
+</svg>

--- a/scripts/build-examples.js
+++ b/scripts/build-examples.js
@@ -14,6 +14,7 @@ const examples = [
   'error-handling',
   'eval-scripts',
   'iri-renumeration',
+  'no-bundler',
   'sprite-usage',
 ]
 

--- a/test/examples.test.ts
+++ b/test/examples.test.ts
@@ -39,6 +39,10 @@ const examples = [
     expectedSvgCount: 3,
   },
   {
+    name: 'no-bundler',
+    expectedSvgCount: 1,
+  },
+  {
     name: 'sprite-usage',
     expectedSvgCount: 3,
   },
@@ -168,6 +172,31 @@ test('eval-scripts: no script elements survive injection', async ({ page }) => {
   // The nested script's sibling is still there, so removal took the script and
   // nothing else.
   await expect(page.locator('#always-slot svg g rect')).toHaveCount(1)
+})
+
+// This example's acceptance criterion is a negative one: nothing in the built
+// page may need a bundler. Every other example ships a chunk under `assets/`
+// that Vite produced from an import of the package name, so the absence of one
+// here, plus a request for the self-hosted `.mjs`, is what says the page really
+// resolved the library by URL in the browser.
+test('no-bundler: the library is loaded by URL, with nothing bundled', async ({
+  page,
+}) => {
+  const paths: string[] = []
+  page.on('request', (request) => paths.push(new URL(request.url()).pathname))
+
+  await page.goto('/no-bundler/dist/')
+  await waitForInjection(page, 1)
+
+  expect(paths).toContain('/no-bundler/dist/svg-injector.mjs')
+  expect(paths.filter((path) => path.includes('/assets/'))).toEqual([])
+
+  await expect(page.locator('#status')).toHaveText(
+    'Injected from ./svg-injector.mjs',
+  )
+  await expect(page.locator('#global')).toHaveText(
+    "typeof window.SVGInjector === 'undefined'",
+  )
 })
 
 test('api-usage: beforeEach applies stroke attribute', async ({ page }) => {


### PR DESCRIPTION
Dropping the UMD builds in 12.0.0 left script-tag users with a four-line esm.sh snippet in `MIGRATION.md` and no worked example. `examples/no-bundler` is the self-hosting half: a static page that imports `dist/svg-injector.mjs` by URL from a copy sitting next to it, injects an SVG, and shows that there is no `window.SVGInjector`.

Also adds a **Without a bundler** subsection under README Installation covering both forms, and links the example from the `MIGRATION.md` UMD entry.

## Not a Vite app

It is the first example that is not a Vite app, and has to be. The plan was to keep it a Vite app and hide the library in `public/`, on the assumption that Vite leaves a `public/` asset alone. It does not: Vite bundles every `<script type="module">` in `index.html` whatever its src resolves to. Measured on Vite 8.2.0:

| src | result |
| --- | --- |
| `./app.mjs` | build fails, `Failed to resolve ./app.mjs from index.html` |
| `/app.mjs` | build succeeds, but emits a bundled chunk into `<head>` and leaves the original tag in the body, so the module runs twice |

So `npm run build` is `node build.js`, which copies `index.html`, `svg.svg` and the library's `.mjs` into `dist/`. That is what a self-hosting consumer does anyway, and it makes the "no bundler" claim true of the example itself rather than only of the page it serves. `npm start` serves `dist/` with `serve`, already a root devDependency.

Two details of the copy, both noted in the example README:

- The library is read from `node_modules/@tanem/svg-injector/dist/svg-injector.mjs` by path, because the `exports` map makes every path inside the package private apart from the root entry and `package.json`.
- `svg-injector.mjs.map` is copied with it, because the `.mjs` ends with a `sourceMappingURL` comment.

All the harness needs from an example is an `npm run build` that fills `<example>/dist/`. `AGENTS.md` now says so, and records the exception.

## Verification

`npm test` green. The new test asserts the negative directly: no request under `assets/`, and a real request for `svg-injector.mjs`. Every other example ships a Vite chunk there, so its absence is what says the page really resolved the library by URL in the browser.

Checked by hand in Chrome 151 as well: three requests — page, module, SVG — and no console output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)