### PR TITLE
Pass the element to afterEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ Collections are snapshotted before injection starts, so a live `HTMLCollection` 
 
 Every option is optional, and `options` itself defaults to `{}`.
 
-| Option                                                      | Type                                                  | Default   |
-| ----------------------------------------------------------- | ----------------------------------------------------- | --------- |
-| [`afterAll`](#afterall)                                     | `(elementsLoaded: number) => void`                    | noop      |
-| [`afterEach`](#aftereach)                                   | `(error: Error \| null, svg?: SVGSVGElement) => void` | noop      |
-| [`beforeEach`](#beforeeach)                                 | `(svg: SVGSVGElement) => void`                        | noop      |
-| [`cacheRequests`](#cacherequests)                           | `boolean`                                             | `true`    |
-| [`evalScripts`](#evalscripts)                               | `'always' \| 'once' \| 'never'`                       | `'never'` |
-| [`httpRequestWithCredentials`](#httprequestwithcredentials) | `boolean`                                             | `false`   |
-| [`renumerateIRIElements`](#renumerateirielements)           | `boolean`                                             | `true`    |
+| Option                                                      | Type                                                                                | Default   |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------- |
+| [`afterAll`](#afterall)                                     | `(elementsLoaded: number) => void`                                                  | noop      |
+| [`afterEach`](#aftereach)                                   | `(error: Error \| null, svg: SVGSVGElement \| undefined, element: Element) => void` | noop      |
+| [`beforeEach`](#beforeeach)                                 | `(svg: SVGSVGElement) => void`                                                      | noop      |
+| [`cacheRequests`](#cacherequests)                           | `boolean`                                                                           | `true`    |
+| [`evalScripts`](#evalscripts)                               | `'always' \| 'once' \| 'never'`                                                     | `'never'` |
+| [`httpRequestWithCredentials`](#httprequestwithcredentials) | `boolean`                                                                           | `false`   |
+| [`renumerateIRIElements`](#renumerateirielements)           | `boolean`                                                                           | `true`    |
 
 #### `afterAll`
 
@@ -91,13 +91,17 @@ Called once per `SVGInjector` call, after every element has been processed. `ele
 
 Called once per element, after it has been injected or after its injection failed. On success `error` is `null` and `svg` is the injected SVG DOM element. On failure `error` is the `Error` and `svg` is `undefined`.
 
+`element` is the element that was passed in, and is present on every call including the failures. It is how a caller that passed a collection tells which placeholder a failure belongs to: on failure there is no `svg` to identify it, several of the error messages don't name their URL, and a URL wouldn't be enough anyway, since two placeholders sharing one `data-src` is the normal case for a sprite. On success it is the original placeholder, already detached and replaced by `svg`.
+
 For every element and every argument, `afterEach` and `afterAll` fire after the `SVGInjector` call has returned. DOM reads placed between the call and the callbacks therefore always see the pre-injection DOM.
 
 ```js
 SVGInjector(document.querySelectorAll('[data-src]'), {
-  afterEach(error, svg) {
+  afterEach(error, svg, element) {
     if (error) {
-      console.error(error)
+      // `element` is the placeholder this error belongs to, and a failed
+      // injection leaves it in the document, so a fallback can go in its place.
+      console.error(`${element.getAttribute('data-src')}: ${error.message}`)
       return
     }
     console.log(`injected ${svg.outerHTML}`)

--- a/examples/error-handling/README.md
+++ b/examples/error-handling/README.md
@@ -4,7 +4,7 @@ Three placeholders, two of which cannot be injected. Both failures come from a r
 
 ## What it shows
 
-- `afterEach` fires once per element on every path, with an `Error` for the two that failed and the injected `<svg>` for the one that succeeded.
+- `afterEach` fires once per element on every path, with an `Error` for the two that failed and the injected `<svg>` for the one that succeeded. Its third argument is the element itself, which is what pairs each error with the placeholder it belongs to.
 - The error messages name their cause: `Unable to load SVG file: missing.svg` and `Invalid content type: text/html`. The content type is checked as soon as the response headers arrive, so a rejected response never has its body parsed.
 - `afterAll` receives the number of elements _processed_, failures included, so it is `3` here while only one SVG reached the page. Count the `afterEach` calls whose `error` is `null` for the number injected.
 - A failed injection leaves its placeholder in the document. Nothing is removed, so there is somewhere to put a fallback.
@@ -21,7 +21,7 @@ Vite's dev server answers an unmatched path with `index.html` and a 200 rather t
 import { SVGInjector } from '@tanem/svg-injector'
 
 SVGInjector(document.getElementsByClassName('inject-me'), {
-  afterEach(error, svg) {
+  afterEach(error, svg, element) {
     if (error) {
       console.error(error)
       return
@@ -38,20 +38,16 @@ Report the error and return. A throw from `afterEach` escapes as an uncaught exc
 
 ## Matching an error back to its element
 
-`afterEach` is called with the error and, on success, the injected SVG. It is not called with the placeholder, and only one of the two messages above names the URL, so a collection cannot pair its failures with their elements from the callback arguments alone.
-
-The example works around it in `afterAll`: an element that injected has been replaced by its SVG, which leaves the failures as the only placeholders still in the document.
+`element` is the third `afterEach` argument, and is the placeholder that was passed in. It is present on every call, failures included, which is what lets a collection put each fallback in the right place:
 
 ```js
-const placeholders = Array.from(document.getElementsByClassName('inject-me'))
-
-SVGInjector(placeholders, {
-  afterAll() {
-    for (const el of placeholders.filter((el) => el.isConnected)) {
-      // el failed
-    }
-  },
-})
+afterEach(error, svg, element) {
+  if (error) {
+    element.replaceWith(fallbackFor(element))
+  }
+}
 ```
 
-That waits for the whole collection. To react per element as soon as it fails, call `SVGInjector` once per placeholder instead and let the closure hold the element. `afterAll` then reports `1` per call rather than the collection total.
+Nothing else in the arguments identifies it. On failure there is no `svg`, only one of the two messages above names its URL, and a URL would not be enough in general anyway: two placeholders sharing one `data-src` is the normal case for a sprite.
+
+The fallback goes in as each element fails. Deriving it instead from which placeholders are still in the document — an element that injected has been replaced by its SVG — works, but only once the whole collection has finished, so one slow load holds back every fallback.

--- a/examples/error-handling/index.ts
+++ b/examples/error-handling/index.ts
@@ -1,43 +1,40 @@
 import { SVGInjector } from '@tanem/svg-injector'
 
-// Snapshotted before the call, because `getElementsByClassName` is live: each
-// placeholder that injects is replaced by its SVG and drops out of the
-// collection, so a later read would only see the failures.
-const placeholders = Array.from(document.getElementsByClassName('inject-me'))
-
 const reported = document.getElementById('reported')!
 const processed = document.getElementById('processed')!
 
-SVGInjector(placeholders, {
-  afterEach(error) {
+let failed = 0
+
+// The live `HTMLCollection` goes straight in: `SVGInjector` snapshots it before
+// injecting anything, so it shrinking as its elements are replaced costs the
+// accounting nothing.
+SVGInjector(document.getElementsByClassName('inject-me'), {
+  afterEach(error, _svg, element) {
     if (!error) {
       return
     }
+
+    failed++
 
     // Reported rather than thrown: a throw from here escapes as an uncaught
     // exception and leaves the rest of the collection to finish without it.
     const item = document.createElement('li')
     item.textContent = error.message
     reported.append(item)
+
+    // `element` is the placeholder this error belongs to. A failed injection
+    // leaves it in the document, so the fallback goes straight in its place,
+    // the moment it fails rather than once the whole collection has finished.
+    const fallback = document.createElement('p')
+    fallback.className = 'fallback'
+    fallback.textContent = `Could not load ${element.getAttribute('data-src')}`
+    element.replaceWith(fallback)
   },
   afterAll(elementsLoaded) {
-    // `afterEach` names the failure but not the element it belongs to, so the
-    // fallbacks are placed here instead: an element that injected has been
-    // replaced by its SVG, which leaves the failures as the only placeholders
-    // still in the document.
-    const failed = placeholders.filter((el) => el.isConnected)
-
-    for (const el of failed) {
-      const fallback = document.createElement('p')
-      fallback.className = 'fallback'
-      fallback.textContent = `Could not load ${el.getAttribute('data-src')}`
-      el.replaceWith(fallback)
-    }
-
     // `elementsLoaded` counts every element processed, the failures included,
     // so it is 3 here rather than the 1 that reached the page.
     processed.textContent = `afterAll(${elementsLoaded}): ${
-      elementsLoaded - failed.length
-    } injected, ${failed.length} failed`
+      elementsLoaded - failed
+    } injected, ${failed} failed`
   },
 })

--- a/src/svg-injector.ts
+++ b/src/svg-injector.ts
@@ -2,15 +2,15 @@ import defer from './defer'
 import injectElement from './inject-element'
 import type {
   AfterAll,
+  AfterEach,
   BeforeEach,
   Elements,
-  Errback,
   EvalScripts,
 } from './types'
 
 interface OptionalArgs {
   afterAll?: AfterAll
-  afterEach?: Errback
+  afterEach?: AfterEach
   beforeEach?: BeforeEach
   cacheRequests?: boolean
   evalScripts?: EvalScripts
@@ -27,6 +27,10 @@ interface OptionalArgs {
 // The completion accounting sits in a `finally` for the same reason: `afterEach`
 // is consumer code, and a throw from it must not cost the collection its
 // `afterAll`. The exception still propagates uncaught afterwards.
+//
+// The third `afterEach` argument is added here rather than in the pipeline
+// because both branches below already hold the element in a closure, so
+// `injectElement` and the load path under it stay per-URL and unchanged.
 const SVGInjector = (
   elements: Elements,
   {
@@ -58,7 +62,7 @@ const SVGInjector = (
       beforeEach,
       (error, svg) => {
         try {
-          afterEach(error, svg)
+          afterEach(error, svg, elements)
         } finally {
           afterAll(1)
         }
@@ -88,7 +92,7 @@ const SVGInjector = (
         beforeEach,
         (error, svg) => {
           try {
-            afterEach(error, svg)
+            afterEach(error, svg, element)
           } finally {
             if (elementList.length === ++elementsLoaded) {
               afterAll(elementsLoaded)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,20 @@
 export type AfterAll = (elementsLoaded: number) => void
 
+// The public `afterEach` option. `element` is the element that was passed in,
+// and is the only way to tell which one a failure belongs to: on failure there
+// is no SVG, several of the error messages do not name their URL, and a URL is
+// not an element in any case, since two placeholders sharing one `data-src` is
+// the normal case for a sprite.
+//
+// `svg` is written `SVGSVGElement | undefined` rather than `svg?` only because
+// a required parameter cannot follow an optional one. It is still absent on
+// every failure path, exactly as before.
+export type AfterEach = (
+  error: Error | null,
+  svg: SVGSVGElement | undefined,
+  element: Element,
+) => void
+
 export type BeforeEach = (svg: SVGSVGElement) => void
 
 // `readonly` so that `as const` arrays and frozen arrays are accepted too: the
@@ -11,6 +26,9 @@ export type Elements =
   | Element
   | null
 
+// The internal load/injection callback, unchanged. Distinct from `AfterEach`
+// because the element is added by `svg-injector.ts`, which already holds it:
+// the load path below it is per-URL and has no element to offer.
 export type Errback = (error: Error | null, svg?: SVGSVGElement) => void
 
 export type EvalScripts = 'always' | 'once' | 'never'

--- a/test/aftereach-element.test.ts
+++ b/test/aftereach-element.test.ts
@@ -1,0 +1,414 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './playwright/coverage'
+import { setupPage, type SvgInjectorWindow } from './playwright/test-utils'
+
+const thumbUpSvgRaw =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8"><path d="M4.47 0c-.19.02-.37.15-.47.34-.13.26-1.09 2.19-1.28 2.38-.19.19-.44.28-.72.28v4h3.5c.21 0 .39-.13.47-.31 0 0 1.03-2.91 1.03-3.19 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.39-1.58.47-1.84c.08-.26-.05-.54-.31-.63-.07-.02-.12-.04-.19-.03zm-4.47 3v4h1v-4h-1z"/></svg>'
+
+const dataUrl = 'data:image/svg+xml,' + encodeURIComponent(thumbUpSvgRaw)
+
+// Same two URLs `callback-timing.test.ts` uses, and for the same reason: they
+// are the shortest triggers for the two paths that fail before any request is
+// made.
+const unparseableDataUrl = 'data:image/svg+xml;charset=shift_jis,x'
+const unparseableUrl = 'http://'
+
+type ElementReport = {
+  error: string | null
+  // `id` of the element `afterEach` received. Read unguarded on purpose: the
+  // argument is typed as always present, so an absent one should fail the test
+  // rather than be quietly reported as "no element".
+  elementId: string
+  // Identity, not equality: the argument has to be the very element that was
+  // passed in, not a copy of it and not the injected SVG. Checked in the page,
+  // because `page.evaluate` only returns serialisable values and a DOM node is
+  // not one.
+  isSamePlaceholder: boolean
+}
+
+type InjectOptions = {
+  cacheRequests?: boolean
+}
+
+// Builds `html` into a container, injects everything matching `.inject-me`,
+// and reports one entry per `afterEach` call. Every placeholder needs an `id`
+// for the report to name it.
+const reportElements = (
+  page: Page,
+  html: string,
+  options: InjectOptions = {},
+) => {
+  return page.evaluate(
+    ({ html, options }) => {
+      return new Promise<ElementReport[]>((resolve) => {
+        const { SVGInjector } = (window as unknown as SvgInjectorWindow)
+          .SVGInjector
+
+        document.body.innerHTML = ''
+        const container = document.createElement('div')
+        container.innerHTML = html
+        document.body.appendChild(container)
+
+        // Snapshotted before the call: `getElementsByClassName` is live, so
+        // each element that injects drops out as it is replaced.
+        const placeholders = Array.from(
+          container.getElementsByClassName('inject-me'),
+        )
+
+        const reports: ElementReport[] = []
+
+        SVGInjector(placeholders, {
+          afterEach: (error: Error | null, _svg, element) => {
+            reports.push({
+              error: error ? error.message : null,
+              elementId: element.id,
+              isSamePlaceholder: placeholders.includes(element),
+            })
+          },
+          afterAll: () => {
+            resolve(reports)
+          },
+          ...options,
+        })
+      })
+    },
+    { html, options },
+  )
+}
+
+const placeholder = (id: string, url: string | null) => {
+  const src = url === null ? '' : ` data-src="${url}"`
+  return `<div id="${id}" class="inject-me"${src}></div>`
+}
+
+// The gap this closes: on failure there is no SVG and no element, so a caller
+// that passed a collection could not say which of its placeholders failed. The
+// error message is not a way back either -- seven of the library's messages do
+// not name their URL, and a URL is not an element in any case, since two
+// placeholders sharing one `data-src` is the normal case for a sprite.
+test.describe('the element afterEach receives', () => {
+  test('is the placeholder on a successful injection', async ({ page }) => {
+    await setupPage(page)
+
+    const reports = await reportElements(
+      page,
+      placeholder('thumb-up', '/fixtures/thumb-up.svg'),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(null)
+    expect(reports[0]!.elementId).toBe('thumb-up')
+    // The placeholder has been replaced by its SVG by now, so this also pins
+    // that the argument is the detached original rather than the replacement.
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder on a cache hit', async ({ page }) => {
+    await setupPage(page)
+
+    await reportElements(page, placeholder('warm', '/fixtures/thumb-up.svg'))
+    const reports = await reportElements(
+      page,
+      placeholder('cached', '/fixtures/thumb-up.svg'),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(null)
+    expect(reports[0]!.elementId).toBe('cached')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder for a data URL', async ({ page }) => {
+    await setupPage(page)
+
+    const reports = await reportElements(page, placeholder('inline', dataUrl))
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(null)
+    expect(reports[0]!.elementId).toBe('inline')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder when the load fails', async ({ page }) => {
+    await setupPage(page, {
+      fixtureOverrides: { '/fixtures/missing.svg': { status: 404 } },
+    })
+
+    const reports = await reportElements(
+      page,
+      placeholder('gone', '/fixtures/missing.svg'),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(
+      'Unable to load SVG file: /fixtures/missing.svg',
+    )
+    expect(reports[0]!.elementId).toBe('gone')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  // `Invalid content type` is one of the messages that does not name its URL,
+  // so before this argument existed nothing in the callback identified the
+  // element. `examples/error-handling` hit exactly this.
+  test('is the placeholder when the content type is rejected', async ({
+    page,
+  }) => {
+    await setupPage(page)
+
+    // The extensionless fixture, because a pathname ending `.svg` bypasses the
+    // content-type check entirely.
+    const reports = await reportElements(
+      page,
+      placeholder('wrong-type', '/fixtures/thumb-up?content-type=text%2Fhtml'),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe('Invalid content type: text/html')
+    expect(reports[0]!.elementId).toBe('wrong-type')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder when the data-src attribute is missing', async ({
+    page,
+  }) => {
+    await setupPage(page)
+
+    const reports = await reportElements(page, placeholder('no-src', null))
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe('Invalid data-src or src attribute')
+    expect(reports[0]!.elementId).toBe('no-src')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder when the data URL is unparseable', async ({
+    page,
+  }) => {
+    await setupPage(page)
+
+    const reports = await reportElements(
+      page,
+      placeholder('bad-data-url', unparseableDataUrl),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe('Unsupported data URL format')
+    expect(reports[0]!.elementId).toBe('bad-data-url')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  // The message here is the browser's own and varies by engine, which is
+  // precisely why the element matters more than the string.
+  test('is the placeholder when the URL is unparseable', async ({ page }) => {
+    await setupPage(page)
+
+    const reports = await reportElements(
+      page,
+      placeholder('bad-url', unparseableUrl),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).not.toBe(null)
+    expect(reports[0]!.elementId).toBe('bad-url')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder when the symbol is not found', async ({ page }) => {
+    await setupPage(page)
+
+    const reports = await reportElements(
+      page,
+      placeholder('no-symbol', '/fixtures/sprite.svg#icon-missing'),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(
+      'Symbol "icon-missing" not found in /fixtures/sprite.svg',
+    )
+    expect(reports[0]!.elementId).toBe('no-symbol')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder when the injection is already in flight', async ({
+    page,
+  }) => {
+    await setupPage(page)
+
+    const reports = await page.evaluate(() => {
+      return new Promise<ElementReport[]>((resolve) => {
+        const { SVGInjector } = (window as unknown as SvgInjectorWindow)
+          .SVGInjector
+
+        document.body.innerHTML = ''
+        const el = document.createElement('div')
+        el.id = 'in-flight'
+        el.setAttribute('data-src', '/fixtures/thumb-up.svg')
+        document.body.appendChild(el)
+
+        const reports: ElementReport[] = []
+
+        // The first call marks the element in flight and owns it until its own
+        // load finishes, so the second call hits the guard.
+        SVGInjector(el)
+        SVGInjector(el, {
+          afterEach: (error: Error | null, _svg, element) => {
+            reports.push({
+              error: error ? error.message : null,
+              elementId: element.id,
+              isSamePlaceholder: element === el,
+            })
+          },
+          afterAll: () => {
+            resolve(reports)
+          },
+        })
+      })
+    })
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(
+      'Injection already in progress: /fixtures/thumb-up.svg',
+    )
+    expect(reports[0]!.elementId).toBe('in-flight')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  test('is the placeholder when the parent node is null', async ({ page }) => {
+    await setupPage(page)
+
+    const reports = await page.evaluate(() => {
+      return new Promise<ElementReport[]>((resolve) => {
+        const { SVGInjector } = (window as unknown as SvgInjectorWindow)
+          .SVGInjector
+
+        document.body.innerHTML = ''
+        // Never appended, so the swap has nothing to replace into.
+        const el = document.createElement('div')
+        el.id = 'detached'
+        el.setAttribute('data-src', '/fixtures/thumb-up.svg')
+
+        const reports: ElementReport[] = []
+
+        SVGInjector(el, {
+          afterEach: (error: Error | null, _svg, element) => {
+            reports.push({
+              error: error ? error.message : null,
+              elementId: element.id,
+              isSamePlaceholder: element === el,
+            })
+          },
+          afterAll: () => {
+            resolve(reports)
+          },
+        })
+      })
+    })
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe('Parent node is null')
+    expect(reports[0]!.elementId).toBe('detached')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+
+  // The point of the ticket. Three placeholders fail three different ways and
+  // one succeeds; each `afterEach` call has to pair its error with its own
+  // element, whatever order the loads finish in.
+  test('pairs each error with its own element in a mixed collection', async ({
+    page,
+  }) => {
+    await setupPage(page, {
+      fixtureOverrides: { '/fixtures/missing.svg': { status: 404 } },
+    })
+
+    const reports = await reportElements(
+      page,
+      [
+        placeholder('ok', '/fixtures/thumb-up.svg'),
+        placeholder('four-oh-four', '/fixtures/missing.svg'),
+        placeholder('no-attribute', null),
+        placeholder('bad-symbol', '/fixtures/sprite.svg#icon-missing'),
+      ].join(''),
+    )
+
+    expect(reports).toHaveLength(4)
+    expect(reports.every((report) => report.isSamePlaceholder)).toBe(true)
+
+    // Sorted because completion order is load order, which is not the source
+    // order and is not guaranteed to be stable across engines.
+    const pairs = reports
+      .map((report) => [report.elementId, report.error])
+      .sort((a, b) => String(a[0]).localeCompare(String(b[0])))
+
+    expect(pairs).toEqual([
+      ['bad-symbol', 'Symbol "icon-missing" not found in /fixtures/sprite.svg'],
+      ['four-oh-four', 'Unable to load SVG file: /fixtures/missing.svg'],
+      ['no-attribute', 'Invalid data-src or src attribute'],
+      ['ok', null],
+    ])
+  })
+
+  // Two placeholders sharing one `data-src` is the normal case for a sprite,
+  // and the reason the URL in an error message is not a substitute for the
+  // element even when the message carries one.
+  test('distinguishes two placeholders sharing one URL', async ({ page }) => {
+    await setupPage(page, {
+      fixtureOverrides: { '/fixtures/missing.svg': { status: 404 } },
+    })
+
+    const reports = await reportElements(
+      page,
+      [
+        placeholder('first', '/fixtures/missing.svg'),
+        placeholder('second', '/fixtures/missing.svg'),
+      ].join(''),
+    )
+
+    expect(reports).toHaveLength(2)
+    expect(reports.every((report) => report.isSamePlaceholder)).toBe(true)
+    expect(reports.map((report) => report.elementId).sort()).toEqual([
+      'first',
+      'second',
+    ])
+  })
+
+  // A single element takes the `nodeType` branch rather than the collection
+  // one, so it is a separate call site and needs its own cover.
+  test('is the element itself when a single element is passed', async ({
+    page,
+  }) => {
+    await setupPage(page)
+
+    const reports = await page.evaluate(() => {
+      return new Promise<ElementReport[]>((resolve) => {
+        const { SVGInjector } = (window as unknown as SvgInjectorWindow)
+          .SVGInjector
+
+        document.body.innerHTML = ''
+        const el = document.createElement('div')
+        el.id = 'lone'
+        el.setAttribute('data-src', '/fixtures/thumb-up.svg')
+        document.body.appendChild(el)
+
+        const reports: ElementReport[] = []
+
+        SVGInjector(el, {
+          afterEach: (error: Error | null, _svg, element) => {
+            reports.push({
+              error: error ? error.message : null,
+              elementId: element.id,
+              isSamePlaceholder: element === el,
+            })
+          },
+          afterAll: () => {
+            resolve(reports)
+          },
+        })
+      })
+    })
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(null)
+    expect(reports[0]!.elementId).toBe('lone')
+    expect(reports[0]!.isSamePlaceholder).toBe(true)
+  })
+})


### PR DESCRIPTION
`afterEach` was called with the error and, on success, the injected SVG. On failure there is neither, so a caller that passed a collection could not say which of its placeholders failed. The error message is not a way back: several of the library's messages do not name their URL, and a URL is not an element in any case, since two placeholders sharing one `data-src` is the normal case for a sprite.

`element` is the element that was passed in, and is present on every call, failures included.

```js
SVGInjector(document.querySelectorAll('[data-src]'), {
  afterEach(error, svg, element) {
    if (error) {
      element.replaceWith(fallbackFor(element))
      return
    }
  },
})
```

## Notes

- **Nothing is threaded through the pipeline.** `svg-injector.ts` already holds the element in a closure at both `injectElement` call sites, so the argument is supplied where the errback is wrapped. `inject-element.ts`, `load-svg-cached.ts` and `load-svg-uncached.ts` are unchanged, and the load path stays per-URL, which is what it should be given sprites.
- **`element` is non-optional**, because every `afterEach` path bottoms out in one of those two closures, including the ones that fail before a URL is known.
- **`Errback` split.** One type served both the public option and the internal load callback. Only the public half gains the element, so `AfterEach` is new and `Errback` stays as it was, still exported.
- **`svg?` became `svg: SVGSVGElement | undefined`**, because a required parameter cannot follow an optional one. Not breaking: in a callback position fewer parameters is always assignable, and `svg?` already had that type. Checked against `@tanem/react-svg`, whose `afterEach` takes two parameters and is unaffected.
- **`beforeEach` deliberately left alone.** It has the same shortcoming, but only fires on the success path, where the SVG that replaced the element already identifies it.

## Tests

14 new tests in `test/aftereach-element.test.ts`, written first, enumerating every path the way `callback-timing.test.ts` does — success, cache hit, data URL, load failure, rejected content type, missing `data-src`, unparseable data URL, unparseable URL, missing symbol, in-flight guard, null parent, a mixed collection, two placeholders sharing one URL, and the single-element branch. The red run confirmed all 14 failed with `element` undefined.

`examples/error-handling` drops the `afterAll` sweep it needed in order to place its fallbacks, and places each one as its element fails. It also passes the live `HTMLCollection` directly again, since the snapshot only existed to support the sweep.

`npm test` green: 402 in the main suite (360 before), 19 in the examples suite, all three browser projects. `size-limit` 4.3 kB against the 5.5 kB budget, so no budget change.

Not checked by hand in a browser: nothing here is engine-dependent — one closure variable and a type — and the suite exercises all 14 paths in Chromium, Firefox and WebKit. `make-ajax-request.ts` and `load-svg-cached.ts` are untouched, so the `test/manual/` transport checks did not need rerunning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)