### PR TITLE
Release via tanem/release-action

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+# Categories for GitHub's generated release notes, keyed by the same labels the
+# release reads to derive the semver bump. `safe to test` authorises CI runs and
+# says nothing about the release, so it is excluded from both.
+changelog:
+  exclude:
+    labels:
+      - safe to test
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking
+    - title: 🚀 Enhancements
+      labels:
+        - enhancement
+    - title: 🛠 Everything Else
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# The filename is load-bearing: npm's trusted publisher for this package
+# matches on repo + workflow filename, so renaming this file means updating the
+# publisher first.
+
 on:
   schedule:
     - cron: '0 9 * * 1' # Every Monday at 9:00 AM UTC
@@ -8,38 +12,36 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Long-lived version branches (v12, v13, ...) stage breaking work until it
+    # is ready to land in one PR. The cron only ever fires on the default
+    # branch, but a manual dispatch can target any branch, and this guard is
+    # what stops one of those publishing a half-finished major.
     if: github.ref == 'refs/heads/master'
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      # Load-bearing: this package has no prepublishOnly, so the dist/ that gets
+      # published is the one `npm test` builds, and the tests gate the release.
+      # They are Playwright tests, so the browsers have to be there first.
+      - run: npm ci
 
-      - name: Install dependencies
-        run: npm ci
+      - run: npx --no-install playwright install --with-deps
 
-      - name: Install Playwright browsers
-        run: npx --no-install playwright install --with-deps
+      - run: npm test
 
-      - name: Release
-        run: npm run release
-        env:
-          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: tanem/release-action@29ffc8b4e3956c1b9532bfb2ad863f31953354a4 # v0.1.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@ constrains belongs there, not here.
   subjects or PR titles. Write a plain capitalised sentence. Nothing reads the
   prefix: the version bump comes from the PR label, and renovate is set to
   `semanticCommits: "disabled"` to match.
-- PR titles are copied verbatim into `CHANGELOG.md`, so write them as the
-  changelog line you want readers to see.
+- PR titles are copied verbatim into the generated release notes, so write them
+  as the changelog line you want readers to see.
 - Hard-wrap commit message bodies at 72 columns; `git log` does not reflow
   them. Do not hard-wrap PR or issue descriptions: GitHub reflows markdown,
   and its web editor leaves wrapped source ragged once anyone edits it.
@@ -124,24 +124,29 @@ what grew first, and say why in the commit message.
 
 ## Releases
 
-`npm run release` runs on a Monday cron against `master`. It takes the version
-bump from the labels on PRs merged since the last tag, then regenerates
-`CHANGELOG.md` and `AUTHORS` and bumps `version` in `package.json` and
-`package-lock.json`.
+[`tanem/release-action`](https://github.com/tanem/release-action) runs on a
+Monday cron against `master`. It takes the version bump from the labels on PRs
+merged since the last tag, bumps `version` in `package.json` and
+`package-lock.json` through `npm version`, tags, then publishes the GitHub
+Release and the npm package.
 
 - **Never leave `master` half-migrated.** The cron publishes whatever is sitting
   on it, so breaking work landing in pieces ships a partial major. Stage it on
   a long-lived version branch (`v12`, `v13`, ...) and merge in one PR. CI runs
   on `v*` branches, and the release workflow's
   `if: github.ref == 'refs/heads/master'` guard stops them self-publishing.
-- Exactly one label per PR, not counting `safe to test`, which the release
-  script filters out before it counts. None, or more than one, throws and
-  blocks the release for everything merged alongside it. `breaking` gives a major,
+- Exactly one label per PR, not counting `safe to test`, which the action
+  filters out before it counts. None, or more than one, throws and blocks the
+  release for everything merged alongside it. `breaking` gives a major,
   `enhancement` a minor, `bug` / `documentation` / `internal` a patch. Tooling,
   CI and dependency work is `internal`.
-- Never hand-edit `CHANGELOG.md`, `AUTHORS` or either `version` field.
+- The changelog is
+  [GitHub Releases](https://github.com/tanem/svg-injector/releases), generated
+  from those same labels via `.github/release.yml`. `CHANGELOG.md` is closed at
+  v12.1.0 — nothing appends to it and nothing should, including you. `AUTHORS`
+  is stale for the same reason. Never hand-edit either `version` field.
 - Breaking changes need a `MIGRATION.md` entry in the same PR: the generated
-  changelog is only a list of PR titles.
+  release notes are only a list of PR titles.
 
 ## Support policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file is frozen history: it covers releases up to and including v12.1.0, and
+is not regenerated any more. Everything released after that lives on
+[GitHub Releases](https://github.com/tanem/svg-injector/releases).
+
 ## [v12.1.0](https://github.com/tanem/svg-injector/tree/v12.1.0) (2026-08-07)
 [Full Changelog](https://github.com/tanem/svg-injector/compare/v12.0.0...v12.1.0)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration
 
-Details relating to major changes that aren't presently in `CHANGELOG.md`, due to limitations with how that file is being generated.
+Details relating to major changes that the release notes don't carry: those are generated from PR titles alone, so anything a reader needs beyond a one-line title lives here.
 
 ## v12.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@tanem/svg-injector",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.5",
@@ -22,7 +22,6 @@
         "serve": "14.2.6",
         "shx": "0.4.0",
         "size-limit": "13.0.2",
-        "tanem-scripts": "8.0.7",
         "tsdown": "0.22.14",
         "typescript": "5.9.3",
         "typescript-eslint": "8.56.1"
@@ -327,207 +326,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@octokit/auth-token": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
-      "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.4",
-        "@octokit/request": "^10.0.13",
-        "@octokit/request-error": "^7.1.1",
-        "@octokit/types": "^17.0.0",
-        "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
-      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^17.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
-      "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^10.0.13",
-        "@octokit/types": "^17.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
-      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "10.0.13",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
-      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^11.0.3",
-        "@octokit/request-error": "^7.1.1",
-        "@octokit/types": "^17.0.0",
-        "content-type": "^2.0.0",
-        "json-with-bigint": "^3.5.3",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
-      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^28.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1697,13 +1495,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/before-after-hook": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/boxen": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
@@ -2102,20 +1893,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2129,17 +1906,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -2681,21 +2447,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
-      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2760,32 +2511,6 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
-    "node_modules/git-remote-origin-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-3.1.0.tgz",
-      "integrity": "sha512-yVSfaTMO7Bqk6Xx3696ufNfjdrajX7Ig9GuAeO2V3Ji7stkDoBNFldnWIAsy0qviUd0Z+X2P6ziJENKztW7cBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gitconfiglocal": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gitconfiglocal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-2.1.0.tgz",
-      "integrity": "sha512-qoerOEliJn3z+Zyn1HW2F6eoYJqKwS6MgC9cztTLUB/xLWX8gD/6T60pKn4+t/d6tP7JlybI7Z3z+I572CR/Vg==",
-      "dev": true,
-      "license": "BSD",
-      "dependencies": {
-        "ini": "^1.3.2"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2798,13 +2523,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3101,33 +2819,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-with-bigint": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
-      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/keypress": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz",
-      "integrity": "sha512-HjorDJFNhnM4SicvaUXac0X77NiskggxJdesG72+O5zBKpSqKFCrqmndKVqpu3pFqkla0St6uGk8Ju0sCurrmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3467,24 +3158,6 @@
         "picocolors": "^1.1.1"
       }
     },
-    "node_modules/native-or-another": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/native-or-another/-/native-or-another-2.0.0.tgz",
-      "integrity": "sha512-rDE50rrX/PSk2StV5EnwpRk35TENl4I4ZsSGZsMJufLdAJ1P4YzNwVf5UOhjQodwz+RdTP9eZSG7FiqnoY25nA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "native-or-bluebird": "^1.1.2"
-      }
-    },
-    "node_modules/native-or-bluebird": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
-      "integrity": "sha512-0SH8UubxDfe382eYiwmd12qxAbiWGzlGZv6CkMA+DPojWa/Y0oH4hE0lRtFfFgJmPQFyKXeB8XxPbZz6TvvKaQ==",
-      "deprecated": "'native-or-bluebird' is deprecated. Please use 'any-promise' instead.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3741,19 +3414,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parse-github-url": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.4.tgz",
-      "integrity": "sha512-CEtCOt55fHmd6DpBc/N7H5NC4vJpcquhzzs9Iw2mRj8bVxo1O5TQI5MXKOMO7+yBOqD+5dKCCRK4Kj1KskZc6Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "parse-github-url": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/parse5": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -3908,17 +3568,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prompt-promise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/prompt-promise/-/prompt-promise-1.0.3.tgz",
-      "integrity": "sha512-xIbGSzK59hFiwn9kmD0Cki4igpUqTVx7c6D8lqZoENAZyTwxhMhh/QleHWoRFVVusi7CTj/ByHP3N+2EmkhKIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "keypress": "~0.2.1",
-        "native-or-another": "~2.0.0"
       }
     },
     "node_modules/publint": {
@@ -4770,37 +4419,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tanem-scripts": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/tanem-scripts/-/tanem-scripts-8.0.7.tgz",
-      "integrity": "sha512-qifMQdYX/ZH0tWR2CwT68Osdov8oCZzzORd+DVpIH9B9Tw0HsZmVAJHIUKTn3JonWQDj3up9LEkXv1W85C7mvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/rest": "^22.0.1",
-        "commander": "^14.0.3",
-        "date-fns": "^4.1.0",
-        "execa": "^5.1.1",
-        "fs-extra": "^11.3.3",
-        "git-remote-origin-url": "^3.1.0",
-        "parse-github-url": "^1.0.3",
-        "prompt-promise": "^1.0.3",
-        "semver": "^7.7.4"
-      },
-      "bin": {
-        "tanem-scripts": "dist/cli.js"
-      }
-    },
-    "node_modules/tanem-scripts/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5053,23 +4671,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-check": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "serve": "14.2.6",
     "shx": "0.4.0",
     "size-limit": "13.0.2",
-    "tanem-scripts": "8.0.7",
     "tsdown": "0.22.14",
     "typescript": "5.9.3",
     "typescript-eslint": "8.56.1"
@@ -89,7 +88,6 @@
     "package:attw": "attw --pack .",
     "package:publint": "publint",
     "postbuild": "run-s package:*",
-    "release": "tanem-scripts release",
     "size": "size-limit",
     "test": "run-s check:* lint build size test:playwright build:examples test:examples:playwright",
     "test:coverage": "run-s check:* lint build size test:playwright:coverage",


### PR DESCRIPTION
Moves this repo's release off the `tanem-scripts` npm package and onto the [`tanem/release-action`](https://github.com/tanem/release-action) composite action, SHA-pinned to v0.1.0. The label-driven bump, the Monday cron and the OIDC provenance publish all carry over unchanged — what goes away is the devDependency, the `RELEASE_TOKEN` PAT and the regenerated `CHANGELOG.md`.

The workflow keeps its filename, which is load-bearing: npm's trusted publisher for this package matches on repo plus workflow filename, so renaming it would need the publisher updated first. `npm ci`, the Playwright browser install and `npm test` are equally load-bearing — this package has no `prepublishOnly`, so the `dist/` that reaches the registry is the one `npm test` builds, and the tests gate the release exactly as they did before. All three were verified locally: a full `npm test` passes and leaves the working tree clean, which matters because `npm version` refuses a dirty tree.

The `if: github.ref == 'refs/heads/master'` guard stays, and is a deliberate deviation from the shape the other fleet repos take. This repo stages breaking work on long-lived `v*` branches; the cron only ever fires on the default branch, but a manual dispatch can target any branch, and without the guard one of those would publish a half-finished major. `AGENTS.md` already documents that guard as load-bearing, so dropping it for uniformity would have been a silent regression.

The push now uses the ambient `GITHUB_TOKEN` instead of `RELEASE_TOKEN`. That required removing master's required `ci` status check, since a push made with `GITHUB_TOKEN` does not trigger workflows and so a bump commit can never earn a check of its own. Force-push and deletion protection stay in place, and Renovate is unaffected — it reads branch status itself rather than relying on GitHub's native auto-merge.

`CHANGELOG.md` is frozen at v12.1.0 with a pointer to GitHub Releases, which becomes the canonical changelog and is generated from the same labels via the new `.github/release.yml`. `AUTHORS` is left in place but is now stale: nothing regenerates it, and removing a contributor credit is a separate call. `AGENTS.md` and `MIGRATION.md` are updated to describe the flow that now exists.

A local dry-run against this repo at the pinned action version reports `Nothing to release: no merged pull requests since the last release`, which is the correct skip for the current state of master.