### PR TITLE
Read the default branch in the release guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     # is ready to land in one PR. The cron only ever fires on the default
     # branch, but a manual dispatch can target any branch, and this guard is
     # what stops one of those publishing a half-finished major.
-    if: github.ref == 'refs/heads/master'
+    if: github.ref_name == github.event.repository.default_branch
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The guard named `master` outright. That is correct here and will stay correct, so this is not a fix — it is alignment with the shape the fleet documents, now that [`tanem/release-action`](https://github.com/tanem/release-action)'s README and §3.1 of the decision spec both read the default branch rather than naming one.

The reading form exists because a literal is a trap in anything meant to be copied: name a branch the repo doesn't have and every release skips, silently and forever. `tanem/release-action` itself is on `main`, and GitHub creates new repos on `main`, while every existing fleet repo is on `master`. The generator will stamp the reading form for the same reason.

Keeping every fleet release workflow on one form means a future reader diffing them against the spec finds no drift to explain.